### PR TITLE
Fixing CI build

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -29,26 +29,13 @@
 
   <Target Name="Build">
 
-    <MakeDir Directories="$(ArtifactsDir);$(PackageOutputPath);$(TemplatesOutputPath);$(DevPath)" />
+    <MakeDir Directories="$(ArtifactsDir);$(PackageOutputPath);$(TemplatesOutputPath);" />
     <CallTarget Targets="CollectGitInfo" />
 
     <!-- Build templates -->
     <MSBuild Projects="template_feed/Template.proj" Targets="Build"
              Condition="'$(TemplatesBuild)' == 'true'"
-             RunEachTargetSeparately="true" StopOnFirstFailure="true" />
-    
-    <!-- Sign the Assemblies before packing -->
-    
-    <MSBuild Condition="'$(PB_SignType)' == 'real' or '$(PB_SignType)' == 'test'"
-             Projects="build\Sign.csproj"
-             Targets="Restore"
-             RunEachTargetSeparately="true" StopOnFirstFailure="true" />
-             
-    <MSBuild Condition="'$(PB_SignType)' == 'real' or '$(PB_SignType)' == 'test'"
-             Projects="sign.proj"
-             Targets="PostCompileSign"
-             RunEachTargetSeparately="true" StopOnFirstFailure="true" />
-             
+             RunEachTargetSeparately="true" StopOnFirstFailure="true" />             
   </Target>
  
   <Target Name="SignPackages">

--- a/build.ps1
+++ b/build.ps1
@@ -34,11 +34,7 @@ else
 
 $RepoRoot = "$PSScriptRoot"
 $ArtifactsDir = "$RepoRoot\artifacts"
-$DevDir = "$RepoRoot\dev"
 $env:CONFIGURATION = $Configuration;
-
-rm "$DevDir" -Force -Recurse
-if(Test-Path "$DevDir") { throw "Failed to remove 'dev'" }
 
 # Use a repo-local install directory (but not the artifacts directory because that gets cleaned a lot
 if (!$env:DOTNET_INSTALL_DIR)

--- a/templates-build.cmd
+++ b/templates-build.cmd
@@ -2,18 +2,12 @@
 
 SET DN3BASEDIR=%~dp0
 
-PUSHD %~dp0\src
 SET DN3B=Release
 echo Using build configuration "%DN3B%"...
 
 SET DN3FFB=$true
 
-CALL "%~dp0\harderreset.cmd"
-
-mkdir %~dp0\dev 1>nul
-
 echo "Calling build.ps1"
 powershell -NoProfile -NoLogo -Command "& \"%~dp0build.ps1\" -Configuration %DN3B% -CIBuild $true -TemplatesBuild $true -PerformFullFrameworkBuild %DN3FFB%; exit $LastExitCode;"
 
 echo Done.
-POPD


### PR DESCRIPTION
Fixing CI build, removing the redundant POPD in templates-build.cmd
Remove Sign calls for assembly signing, there is no sign proj yet.
Removing creation of dev folder.
Removing the call to harderreset.cmd