### PR TITLE
Dev16 changes

### DIFF
--- a/Templates/CSharp/Desktop/source.extension.vsixmanifest
+++ b/Templates/CSharp/Desktop/source.extension.vsixmanifest
@@ -8,12 +8,12 @@
     <PackageId>Microsoft.VisualStudio.Templates.CS.MSTestv2.Desktop.UnitTest</PackageId>
   </Metadata>
   <Installation AllUsers="true" SystemComponent="true">
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0]" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.Enterprise" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.VSWinExpress" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.VWDExpress" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0]" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.VSWinExpress" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.VWDExpress" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -22,6 +22,6 @@
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\CSharp\Test\Desktop.zip" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0]" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0]" DisplayName="Visual Studio core editor" />
   </Prerequisites>
 </PackageManifest>

--- a/Templates/CSharp/UWP/ProjectTemplates/CSharp/Windows UAP/MSTestV2UWP.vstemplate
+++ b/Templates/CSharp/UWP/ProjectTemplates/CSharp/Windows UAP/MSTestV2UWP.vstemplate
@@ -41,7 +41,7 @@
     </Project>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Microsoft.VisualStudio.WinRT.TemplateWizards, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <Assembly>Microsoft.VisualStudio.WinRT.TemplateWizards, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
     <FullClassName>Microsoft.VisualStudio.WinRT.TemplateWizards.CreateProjectCertificate.Wizard</FullClassName>
   </WizardExtension>
   <WizardExtension>
@@ -49,7 +49,7 @@
     <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
   </WizardExtension>
   <WizardExtension>
-    <Assembly>Microsoft.VisualStudio.Universal.TemplateWizards, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <Assembly>Microsoft.VisualStudio.Universal.TemplateWizards, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
     <FullClassName>Microsoft.VisualStudio.Universal.TemplateWizards.PlatformVersion.Wizard</FullClassName>
   </WizardExtension>
   <WizardData>

--- a/Templates/CSharp/UWP/source.extension.vsixmanifest
+++ b/Templates/CSharp/UWP/source.extension.vsixmanifest
@@ -8,12 +8,12 @@
     <PackageId>Microsoft.VisualStudio.Templates.CS.MSTestv2.UWP.UnitTest</PackageId>
   </Metadata>
   <Installation AllUsers="true" SystemComponent="true">
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0]" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.Enterprise" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.VSWinExpress" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.VWDExpress" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0]" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.VSWinExpress" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.VWDExpress" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -22,6 +22,6 @@
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\CSharp\Windows UAP\UWP.zip" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0]" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0]" DisplayName="Visual Studio core editor" />
   </Prerequisites>
 </PackageManifest>

--- a/Templates/VisualBasic/Desktop/source.extension.vsixmanifest
+++ b/Templates/VisualBasic/Desktop/source.extension.vsixmanifest
@@ -8,12 +8,12 @@
     <PackageId>Microsoft.VisualStudio.Templates.VB.MSTestv2.Desktop.UnitTest</PackageId>
   </Metadata>
   <Installation AllUsers="true" SystemComponent="true">
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0]" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.Enterprise" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.VSWinExpress" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.VWDExpress" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0]" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.VSWinExpress" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.VWDExpress" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -22,6 +22,6 @@
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\VisualBasic\Test\VBDesktopUnitTestTemplate.zip" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0]" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0]" DisplayName="Visual Studio core editor" />
   </Prerequisites>
 </PackageManifest>

--- a/Templates/VisualBasic/UWP/ProjectTemplates/VisualBasic/Windows UAP/MSTestV2UWP_VB.vstemplate
+++ b/Templates/VisualBasic/UWP/ProjectTemplates/VisualBasic/Windows UAP/MSTestV2UWP_VB.vstemplate
@@ -41,7 +41,7 @@
     </Project>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Microsoft.VisualStudio.WinRT.TemplateWizards, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <Assembly>Microsoft.VisualStudio.WinRT.TemplateWizards, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
     <FullClassName>Microsoft.VisualStudio.WinRT.TemplateWizards.CreateProjectCertificate.Wizard</FullClassName>
   </WizardExtension>
   <WizardExtension>
@@ -49,7 +49,7 @@
     <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
   </WizardExtension>
   <WizardExtension>
-    <Assembly>Microsoft.VisualStudio.Universal.TemplateWizards, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <Assembly>Microsoft.VisualStudio.Universal.TemplateWizards, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
     <FullClassName>Microsoft.VisualStudio.Universal.TemplateWizards.PlatformVersion.Wizard</FullClassName>
   </WizardExtension> 
   <WizardData>

--- a/Templates/VisualBasic/UWP/source.extension.vsixmanifest
+++ b/Templates/VisualBasic/UWP/source.extension.vsixmanifest
@@ -8,12 +8,12 @@
     <PackageId>Microsoft.VisualStudio.Templates.VB.MSTestv2.UWP.UnitTest</PackageId>
   </Metadata>
   <Installation AllUsers="true" SystemComponent="true">
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0]" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.Enterprise" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.VSWinExpress" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.VWDExpress" />
-    <InstallationTarget Version="[15.0]" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0]" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.VSWinExpress" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.VWDExpress" />
+    <InstallationTarget Version="[16.0]" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -22,6 +22,6 @@
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\VisualBasic\Windows UAP\UWP_VB.zip" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0]" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0]" DisplayName="Visual Studio core editor" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Changing the vsix manifests so that templates get installed only in Dev16.
Fixed the UWP template references to point to the correct version.