### PR TITLE
Remove the Selenium web driver from the packages

### DIFF
--- a/Templates/CSharp/EdgeDriverTemplate/DotNetFramwork/EdgeDriverTemplate.csproj
+++ b/Templates/CSharp/EdgeDriverTemplate/DotNetFramwork/EdgeDriverTemplate.csproj
@@ -75,9 +75,8 @@
     <Content Include="packages\MSTest.TestFramework.1.3.2.nupkg">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="packages\selenium.webdriver.3.14.0.nupkg">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
+    <!-- selenium.webdriver is not included here because it is not owned by Microsoft.
+    Therefore we can't sign it to let it be included in VS.-->
   </ItemGroup>
   <ItemGroup>
     <VSTemplate Include="ProjectTemplates\CSharp\Test\EdgeDriverTemplate.vstemplate" />

--- a/Templates/CSharp/EdgeDriverTemplate/DotNetFramwork/ProjectTemplates/CSharp/Test/EdgeDriverSample.csproj
+++ b/Templates/CSharp/EdgeDriverTemplate/DotNetFramwork/ProjectTemplates/CSharp/Test/EdgeDriverSample.csproj
@@ -31,6 +31,9 @@
     <Reference Include="System.Drawing" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Selenium.WebDriver" Version="3.14.0"/>
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="EdgeDriverTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Templates/CSharp/EdgeDriverTemplate/DotNetFramwork/ProjectTemplates/CSharp/Test/EdgeDriverTemplate.vstemplate
+++ b/Templates/CSharp/EdgeDriverTemplate/DotNetFramwork/ProjectTemplates/CSharp/Test/EdgeDriverTemplate.vstemplate
@@ -27,7 +27,6 @@
     <packages repository="extension" repositoryId="EdgeDriverTest.0b43ac6b-e6ff-4afc-a5f6-286d41c046a6" isPreunzipped="false">
       <package id="MSTest.TestAdapter" version="1.3.2" skipAssemblyReferences="false"/>
       <package id="MSTest.TestFramework" version="1.3.2" skipAssemblyReferences="false"/>
-      <package id="Selenium.WebDriver" version="3.14.0" skipAssemblyReferences="false"/>
     </packages>
   </WizardData>
 </VSTemplate>

--- a/src/Setup/Microsoft.VisualStudio.Templates.CS.EdgeDriverTestCore.vsmanproj
+++ b/src/Setup/Microsoft.VisualStudio.Templates.CS.EdgeDriverTestCore.vsmanproj
@@ -7,7 +7,6 @@
     <FinalizeSkipLayout>true</FinalizeSkipLayout>
     <IsPackage>true</IsPackage>
     <OutputPath>$(TestTemplatesRoot)\artifacts\$(Configuration)\v3vsix</OutputPath>
-    <TargetFrameworkVersion>netcoreapp2.1</TargetFrameworkVersion>
     <UseVisualStudioVersion>true</UseVisualStudioVersion>
     <ValidateManifest>false</ValidateManifest>
   </PropertyGroup>

--- a/src/Setup/Microsoft.VisualStudio.Templates.CS.EdgeDriverTestCore.vsmanproj
+++ b/src/Setup/Microsoft.VisualStudio.Templates.CS.EdgeDriverTestCore.vsmanproj
@@ -7,7 +7,7 @@
     <FinalizeSkipLayout>true</FinalizeSkipLayout>
     <IsPackage>true</IsPackage>
     <OutputPath>$(TestTemplatesRoot)\artifacts\$(Configuration)\v3vsix</OutputPath>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>netcoreapp2.1</TargetFrameworkVersion>
     <UseVisualStudioVersion>true</UseVisualStudioVersion>
     <ValidateManifest>false</ValidateManifest>
   </PropertyGroup>

--- a/src/Setup/Microsoft.VisualStudio.Templates.CS.EdgeDriverTestCore.vsmanproj
+++ b/src/Setup/Microsoft.VisualStudio.Templates.CS.EdgeDriverTestCore.vsmanproj
@@ -8,6 +8,7 @@
     <IsPackage>true</IsPackage>
     <OutputPath>$(TestTemplatesRoot)\artifacts\$(Configuration)\v3vsix</OutputPath>
     <UseVisualStudioVersion>true</UseVisualStudioVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <ValidateManifest>false</ValidateManifest>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RunningInMicroBuild)' != 'true'"> 

--- a/src/Setup/Microsoft.VisualStudio.Templates.CS.EdgeDriverTestCore.vsmanproj
+++ b/src/Setup/Microsoft.VisualStudio.Templates.CS.EdgeDriverTestCore.vsmanproj
@@ -7,8 +7,8 @@
     <FinalizeSkipLayout>true</FinalizeSkipLayout>
     <IsPackage>true</IsPackage>
     <OutputPath>$(TestTemplatesRoot)\artifacts\$(Configuration)\v3vsix</OutputPath>
-    <UseVisualStudioVersion>true</UseVisualStudioVersion>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <UseVisualStudioVersion>true</UseVisualStudioVersion>
     <ValidateManifest>false</ValidateManifest>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RunningInMicroBuild)' != 'true'"> 


### PR DESCRIPTION
When I was trying to build VS [here](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2220858&_a=summary&view=logs), the log says it fails because of Selenium web driver is not signed. Shyam and I have checked and removed the web driver from the nuget package and put it into the package reference. (Since Selenium web driver is not owned by us so we can't sign it to let it included in VS)

I have tested it on my local machine.
