### PR TITLE
Fix precendence of .Net core templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-This repository is the home for the .NET Core Test Templates. It also contains Classic .Net Framework and Universal Test templates for C# and VB. 
+This repository is home for the .NET Core Test Templates. It also contains Classic .Net Framework and Universal Test templates for C# and VB. 
 
 # Creating new projects
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-This repository is home for the .NET Core Test Templates. It also contains Classic .Net Framework and Universal Test templates for C# and VB. 
+This repository is the home for the .NET Core Test Templates. It also contains Classic .Net Framework and Universal Test templates for C# and VB. 
 
 # Creating new projects
 

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.2/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.2/content/MSTest-CSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains unit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.MSTest",
-  "precedence": "3000",
+  "precedence": "4000",
   "identity": "Microsoft.Test.MSTest.CSharp.2.2",
   "shortName": "mstest",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.2/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.2/content/MSTest-FSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains unit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.MSTest",
-  "precedence": "3000",
+  "precedence": "4000",
   "identity": "Microsoft.Test.MSTest.FSharp.2.2",
   "shortName": "mstest",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.2/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.2/content/MSTest-VisualBasic/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains unit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.MSTest",
-  "precedence": "3000",
+  "precedence": "4000",
   "identity": "Microsoft.Test.MSTest.VisualBasic.2.2",
   "shortName": "mstest",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.2/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.2/content/XUnit-CSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
-  "precedence": "3000",
+  "precedence": "4000",
   "identity": "Microsoft.Test.xUnit.CSharp.2.2",
   "shortName": "xunit",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.2/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.2/content/XUnit-FSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
-  "precedence": "3000",
+  "precedence": "4000",
   "identity": "Microsoft.Test.xUnit.FSharp.2.2",
   "shortName": "xunit",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.2/content/XUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.2/content/XUnit-VisualBasic/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
-  "precedence": "3000",
+  "precedence": "4000",
   "identity": "Microsoft.Test.xUnit.VisualBasic.2.2",
   "shortName": "xunit",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/MSTest-CSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains unit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.MSTest",
-  "precedence": "3000",
+  "precedence": "5000",
   "identity": "Microsoft.Test.MSTest.CSharp.3.0",
   "shortName": "mstest",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/MSTest-FSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains unit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.MSTest",
-  "precedence": "3000",
+  "precedence": "5000",
   "identity": "Microsoft.Test.MSTest.FSharp.3.0",
   "shortName": "mstest",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains unit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.MSTest",
-  "precedence": "3000",
+  "precedence": "5000",
   "identity": "Microsoft.Test.MSTest.VisualBasic.3.0",
   "shortName": "mstest",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/XUnit-CSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
-  "precedence": "3000",
+  "precedence": "5000",
   "identity": "Microsoft.Test.xUnit.CSharp.3.0",
   "shortName": "xunit",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/XUnit-FSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
-  "precedence": "3000",
+  "precedence": "5000",
   "identity": "Microsoft.Test.xUnit.FSharp.3.0",
   "shortName": "xunit",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/XUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/XUnit-VisualBasic/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
-  "precedence": "3000",
+  "precedence": "5000",
   "identity": "Microsoft.Test.xUnit.VisualBasic.3.0",
   "shortName": "xunit",
   "tags": {


### PR DESCRIPTION
Fixing the precendence for the .Net core test templates targeting 2.2 and 3.0
