### PR TITLE
Add feeds from Versions.props to NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -8,7 +8,13 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="vstest" value="https://dotnet.myget.org/F/vstest/api/v3/index.json" />
     <add key="mstestv2" value="https://dotnet.myget.org/F/mstestv2/auth/1e768268-8c95-4e7e-9fd2-0eb1b1b69b18/api/v3/index.json" />
-    <add key="pdb2pdb.myget" value="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json" /> 
+    <add key="pdb2pdb.myget" value="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json" />
+    <add key="dotnet-core.myget" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
+    <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
+    <add key="dotnet-web" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
+    <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
+    <add key="roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
   </packageSources>
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />


### PR DESCRIPTION
We need all restore sources to be located in NuGet.config since internal feeds can only be restored from there. More details including next steps [here](https://github.com/dotnet/arcade/blob/master/Documentation/RestoreSourcesUpdateStatus.md)