### PR TITLE
Fix generation of VB Template

### DIFF
--- a/Templates/VisualBasic/Desktop/MSTestDesktopVB.csproj
+++ b/Templates/VisualBasic/Desktop/MSTestDesktopVB.csproj
@@ -8,13 +8,13 @@
     <EnableDefaultItems>false</EnableDefaultItems>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <!-- VS Insertion -->
-    <!--VisualStudioInsertionComponent>Microsoft.VisualStudio.Templates.VB.MSTestv2.Desktop.UnitTest</VisualStudioInsertionComponent-->
+    <VisualStudioInsertionComponent>Microsoft.VisualStudio.Templates.VB.MSTestv2.Desktop.UnitTest</VisualStudioInsertionComponent>
 
     <CreateVsixContainer>true</CreateVsixContainer>
     <DeployExtension>False</DeployExtension>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
-<ItemGroup>
+  <ItemGroup>
     <Content Include="DesktopTemplateLicense.rtf">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>


### PR DESCRIPTION
Fix the MSTestDesktopVB templates to be part of the VS insertion components