### PR TITLE
Enabling templates to show in Client compliance mode.

### DIFF
--- a/Templates/CSharp/Desktop/source.extension.vsixmanifest
+++ b/Templates/CSharp/Desktop/source.extension.vsixmanifest
@@ -6,6 +6,7 @@
     <Description xml:space="preserve">Provides Visual Studio project template for MSTest V2.</Description>
     <License>DesktopTemplateLicense.rtf</License>
     <PackageId>Microsoft.VisualStudio.Templates.CS.MSTestv2.Desktop.UnitTest</PackageId>
+    <AllowClientRole>true</AllowClientRole>
   </Metadata>
   <Installation AllUsers="true" Experimental="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0]" />

--- a/Templates/CSharp/EdgeDriverTemplate/DotNetCore/EdgeDriverTemplateCore/source.extension.vsixmanifest
+++ b/Templates/CSharp/EdgeDriverTemplate/DotNetCore/EdgeDriverTemplateCore/source.extension.vsixmanifest
@@ -5,6 +5,7 @@
         <DisplayName>Web Driver Test Template For Edge (.NET Core)</DisplayName>
         <Description xml:space="preserve">Create an automatic UI test using Edge Driver.</Description>
         <PackageId>Microsoft.VisualStudio.Templates.CS.EdgeDriverTestCore</PackageId>
+        <AllowClientRole>true</AllowClientRole>
     </Metadata>
     <Installation AllUsers="true" Experimental="true">
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />

--- a/Templates/CSharp/EdgeDriverTemplate/DotNetFramwork/source.extension.vsixmanifest
+++ b/Templates/CSharp/EdgeDriverTemplate/DotNetFramwork/source.extension.vsixmanifest
@@ -5,6 +5,7 @@
         <DisplayName>Web Driver Test Template For Edge (.NET Framework)</DisplayName>
         <Description xml:space="preserve">Create an automatic UI test using Edge Driver.</Description>
         <PackageId>Microsoft.VisualStudio.Templates.CS.EdgeDriverTest</PackageId>
+        <AllowClientRole>true</AllowClientRole>
     </Metadata>
     <Installation AllUsers="true" Experimental="true">
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />

--- a/Templates/VisualBasic/Desktop/source.extension.vsixmanifest
+++ b/Templates/VisualBasic/Desktop/source.extension.vsixmanifest
@@ -6,6 +6,7 @@
     <Description xml:space="preserve">Provides Visual Studio project template for MSTest V2(Visual Basic).</Description>
     <License>DesktopTemplateLicense.rtf</License>
     <PackageId>Microsoft.VisualStudio.Templates.VB.MSTestv2.Desktop.UnitTest</PackageId>
+    <AllowClientRole>true</AllowClientRole>
   </Metadata>
   <Installation AllUsers="true" Experimental="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0]" />

--- a/WizardExtensions/MSTestv2UnitTestExtension/MSTestv2UnitTestExtension.csproj
+++ b/WizardExtensions/MSTestv2UnitTestExtension/MSTestv2UnitTestExtension.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="VSLangProj" Version="$(VSLangProjVersion)"/>
     <PackageReference Include="VSLangProj80" Version="$(VSLangProj80Version)"/>
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(MicrosoftVisualStudioComponentModelHostVersion)"/>
+    <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="$(MicrosoftVSSDKEmbedInteropTypesVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="envdte">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,5 +19,8 @@
     <VSLangProjVersion>7.0.3301.0</VSLangProjVersion>
     <VSLangProj80Version>8.0.50728</VSLangProj80Version>
     <MicrosoftVisualStudioComponentModelHostVersion>16.0.342-g758a0a97e0</MicrosoftVisualStudioComponentModelHostVersion>
+    <MicrosoftVSSDKEmbedInteropTypesVersion>15.0.29</MicrosoftVSSDKEmbedInteropTypesVersion>
+    <!-- Arcade tooling dependencies-->
+    <MicrosoftVSSDKBuildToolsVersion>16.7.2</MicrosoftVSSDKBuildToolsVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Todo:
the current version of the VSSDK does not mark the vsix to be client compliant because it does not include a pkgdef file.