### PR TITLE
Remove duplicated defaultName attribute

### DIFF
--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/template.json
@@ -3,7 +3,6 @@
   "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
   "classifications": [ "Test", "NUnit" ],
   "name": "NUnit 3 Test Project",
-  "defaultName": "NUnitTestProject",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/template.json
@@ -3,7 +3,6 @@
   "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
   "classifications": [ "Test", "NUnit" ],
   "name": "NUnit 3 Test Project",
-  "defaultName": "NUnitTestProject",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/template.json
@@ -3,7 +3,6 @@
   "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
   "classifications": [ "Test", "NUnit" ],
   "name": "NUnit 3 Test Project",
-  "defaultName": "NUnitTestProject",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",


### PR DESCRIPTION
I've noticed that NUnit test project template.json files have duplicate defaultName entries. In this PR duplicated defaultName attributes are removed.