### PR TITLE
Fix net6.0 templates priority

### DIFF
--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains unit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.MSTest",
-  "precedence": "7000",
+  "precedence": "8000",
   "identity": "Microsoft.Test.MSTest.CSharp.6.0",
   "shortName": "mstest",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains unit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.MSTest",
-  "precedence": "7000",
+  "precedence": "8000",
   "identity": "Microsoft.Test.MSTest.FSharp.6.0",
   "shortName": "mstest",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains unit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.MSTest",
-  "precedence": "7000",
+  "precedence": "8000",
   "identity": "Microsoft.Test.MSTest.VisualBasic.6.0",
   "shortName": "mstest",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/template.json
@@ -7,7 +7,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
-  "precedence": "7000",
+  "precedence": "8000",
   "identity": "NUnit3.DotNetNew.Template.CSharp.6.0",
   "shortName": "nunit",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/template.json
@@ -7,7 +7,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
-  "precedence": "7000",
+  "precedence": "8000",
   "identity": "NUnit3.DotNetNew.Template.FSharp.6.0",
   "shortName": "nunit",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/template.json
@@ -7,7 +7,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
-  "precedence": "7000",
+  "precedence": "8000",
   "identity": "NUnit3.DotNetNew.Template.VisualBasic.6.0",
   "shortName": "nunit",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
-  "precedence": "7000",
+  "precedence": "8000",
   "identity": "Microsoft.Test.xUnit.CSharp.6.0",
   "shortName": "xunit",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
-  "precedence": "7000",
+  "precedence": "8000",
   "identity": "Microsoft.Test.xUnit.FSharp.6.0",
   "shortName": "xunit",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
-  "precedence": "7000",
+  "precedence": "8000",
   "identity": "Microsoft.Test.xUnit.VisualBasic.6.0",
   "shortName": "xunit",
   "tags": {


### PR DESCRIPTION
Setting precedence of net6.0 templates to 8000 to avoid conflict with net5.0 templates.