### PR TITLE
Removing core word from template name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Let's create a new test project named "NewMSTestProject" in the "src/MyTest" dir
 
 ```bash
 $ dotnet new mstest -n NewMSTestProject 
-The template "MSTest Test Project (.NET Core)" was created successfully.
+The template "MSTest Test Project" was created successfully.
 ```
 
 The project was successfully created on disk as expected in `src/MyTest`. From here, we can run normal `dotnet` commands like `dotnet restore` and `dotnet build`.

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testů MSTest (.NET Core)",
+    "name": "Projekt testů MSTest",
     "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest-Testprojekt (.NET Core)",
+    "name": "MSTest-Testprojekt",
     "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest Test Project (.NET Core)",
+    "name": "MSTest Test Project",
     "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de prueba de MSTest (.NET Core)",
+    "name": "Proyecto de prueba de MSTest",
     "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test MSTest (.NET Core)",
+    "name": "Projet de test MSTest ",
     "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di test MSTest (.NET Core)",
+    "name": "Progetto di test MSTest",
     "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest テスト プロジェクト (.NET Core)",
+    "name": "MSTest テスト プロジェクト",
     "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest 테스트 프로젝트(.NET Core)",
+    "name": "MSTest 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testów MSTest (.NET Core)",
+    "name": "Projekt testów MSTest",
     "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de Teste MSTest (.NET Core)",
+    "name": "Projeto de Teste MSTest",
     "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Проект тестов MSTest (.NET Core)",
+    "name": "Проект тестов MSTest",
     "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": [ "Test", "MSTest" ],
-  "name": "MSTest Test Project (.NET Core)",
+  "name": "MSTest Test Project",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest Test Projesi (.NET Core)",
+    "name": "MSTest Test Projesi",
     "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest 测试项目(.NET Core)",
+    "name": "MSTest 测试项目",
     "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest 測試專案 (.NET Core)",
+    "name": "MSTest 測試專案",
     "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testů MSTest (.NET Core)",
+    "name": "Projekt testů MSTest",
     "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest-Testprojekt (.NET Core)",
+    "name": "MSTest-Testprojekt",
     "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest Test Project (.NET Core)",
+    "name": "MSTest Test Project",
     "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de prueba de MSTest (.NET Core)",
+    "name": "Proyecto de prueba de MSTest",
     "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test MSTest (.NET Core)",
+    "name": "Projet de test MSTest ",
     "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di test MSTest (.NET Core)",
+    "name": "Progetto di test MSTest",
     "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest テスト プロジェクト (.NET Core)",
+    "name": "MSTest テスト プロジェクト",
     "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest 테스트 프로젝트(.NET Core)",
+    "name": "MSTest 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testów MSTest (.NET Core)",
+    "name": "Projekt testów MSTest",
     "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de Teste MSTest (.NET Core)",
+    "name": "Projeto de Teste MSTest",
     "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Проект тестов MSTest (.NET Core)",
+    "name": "Проект тестов MSTest",
     "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Test", "MSTest"],
-  "name": "MSTest Test Project (.NET Core)",
+  "name": "MSTest Test Project",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest Test Projesi (.NET Core)",
+    "name": "MSTest Test Projesi",
     "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest 测试项目(.NET Core)",
+    "name": "MSTest 测试项目",
     "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest 測試專案 (.NET Core)",
+    "name": "MSTest 測試專案",
     "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testů MSTest (.NET Core)",
+    "name": "Projekt testů MSTest",
     "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest-Testprojekt (.NET Core)",
+    "name": "MSTest-Testprojekt",
     "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest Test Project (.NET Core)",
+    "name": "MSTest Test Project",
     "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de prueba de MSTest (.NET Core)",
+    "name": "Proyecto de prueba de MSTest",
     "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test MSTest (.NET Core)",
+    "name": "Projet de test MSTest ",
     "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di test MSTest (.NET Core)",
+    "name": "Progetto di test MSTest",
     "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest テスト プロジェクト (.NET Core)",
+    "name": "MSTest テスト プロジェクト",
     "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest 테스트 프로젝트(.NET Core)",
+    "name": "MSTest 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testów MSTest (.NET Core)",
+    "name": "Projekt testów MSTest",
     "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de Teste MSTest (.NET Core)",
+    "name": "Projeto de Teste MSTest",
     "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Проект тестов MSTest (.NET Core)",
+    "name": "Проект тестов MSTest",
     "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Test", "MSTest"],
-  "name": "MSTest Test Project (.NET Core)",
+  "name": "MSTest Test Project",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest Test Projesi (.NET Core)",
+    "name": "MSTest Test Projesi",
     "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest 测试项目(.NET Core)",
+    "name": "MSTest 测试项目",
     "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest 測試專案 (.NET Core)",
+    "name": "MSTest 測試專案",
     "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testu NUnit (.NET Core)",
+    "name": "Projekt testu NUnit",
     "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit-Testprojekt (.NET Core)",
+    "name": "NUnit-Testprojekt",
     "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Project (.NET Core)",
+    "name": "NUnit Test Project",
     "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de prueba NUnit (.NET Core)",
+    "name": "Proyecto de prueba NUnit",
     "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test NUnit (.NET Core)",
+    "name": "Projet de test NUnit",
     "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di Test NUnit (.NET Core)",
+    "name": "Progetto di Test NUnit",
     "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit テスト プロジェクト (.NET Core)",
+    "name": "NUnit テスト プロジェクト",
     "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 테스트 프로젝트(.NET Core)",
+    "name": "NUnit 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testowy NUnit (.NET Core)",
+    "name": "Projekt testowy NUnit",
     "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de teste NUnit (.NET Core)",
+    "name": "Projeto de teste NUnit",
     "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Тестовый проект NUnit (.NET Core)",
+    "name": "Тестовый проект NUnit",
     "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Projesi (.NET Core)",
+    "name": "NUnit Test Projesi",
     "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 测试项目(.NET Core)",
+    "name": "NUnit 测试项目",
     "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 測試專案 (.NET Core)",
+    "name": "NUnit 測試專案",
     "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testu NUnit (.NET Core)",
+    "name": "Projekt testu NUnit",
     "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit-Testprojekt (.NET Core)",
+    "name": "NUnit-Testprojekt",
     "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Project (.NET Core)",
+    "name": "NUnit Test Project",
     "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de prueba NUnit (.NET Core)",
+    "name": "Proyecto de prueba NUnit",
     "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test NUnit (.NET Core)",
+    "name": "Projet de test NUnit",
     "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di Test NUnit (.NET Core)",
+    "name": "Progetto di Test NUnit",
     "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit テスト プロジェクト (.NET Core)",
+    "name": "NUnit テスト プロジェクト",
     "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 테스트 프로젝트(.NET Core)",
+    "name": "NUnit 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testowy NUnit (.NET Core)",
+    "name": "Projekt testowy NUnit",
     "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de teste NUnit (.NET Core)",
+    "name": "Projeto de teste NUnit",
     "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Тестовый проект NUnit (.NET Core)",
+    "name": "Тестовый проект NUnit",
     "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Projesi (.NET Core)",
+    "name": "NUnit Test Projesi",
     "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 测试项目(.NET Core)",
+    "name": "NUnit 测试项目",
     "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 測試專案 (.NET Core)",
+    "name": "NUnit 測試專案",
     "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testu NUnit (.NET Core)",
+    "name": "Projekt testu NUnit",
     "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit-Testprojekt (.NET Core)",
+    "name": "NUnit-Testprojekt",
     "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Project (.NET Core)",
+    "name": "NUnit Test Project",
     "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de prueba NUnit (.NET Core)",
+    "name": "Proyecto de prueba NUnit",
     "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test NUnit (.NET Core)",
+    "name": "Projet de test NUnit",
     "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di Test NUnit (.NET Core)",
+    "name": "Progetto di Test NUnit",
     "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit テスト プロジェクト (.NET Core)",
+    "name": "NUnit テスト プロジェクト",
     "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 테스트 프로젝트(.NET Core)",
+    "name": "NUnit 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testowy NUnit (.NET Core)",
+    "name": "Projekt testowy NUnit",
     "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de teste NUnit (.NET Core)",
+    "name": "Projeto de teste NUnit",
     "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Тестовый проект NUnit (.NET Core)",
+    "name": "Тестовый проект NUnit",
     "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Projesi (.NET Core)",
+    "name": "NUnit Test Projesi",
     "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 测试项目(.NET Core)",
+    "name": "NUnit 测试项目",
     "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 測試專案 (.NET Core)",
+    "name": "NUnit 測試專案",
     "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testu NUnit (.NET Core)",
+    "name": "Projekt testu NUnit",
     "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit-Testprojekt (.NET Core)",
+    "name": "NUnit-Testprojekt",
     "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Project (.NET Core)",
+    "name": "NUnit Test Project",
     "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de prueba NUnit (.NET Core)",
+    "name": "Proyecto de prueba NUnit",
     "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test NUnit (.NET Core)",
+    "name": "Projet de test NUnit",
     "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di Test NUnit (.NET Core)",
+    "name": "Progetto di Test NUnit",
     "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit テスト プロジェクト (.NET Core)",
+    "name": "NUnit テスト プロジェクト",
     "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 테스트 프로젝트(.NET Core)",
+    "name": "NUnit 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testowy NUnit (.NET Core)",
+    "name": "Projekt testowy NUnit",
     "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de teste NUnit (.NET Core)",
+    "name": "Projeto de teste NUnit",
     "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Тестовый проект NUnit (.NET Core)",
+    "name": "Тестовый проект NUnit",
     "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Projesi (.NET Core)",
+    "name": "NUnit Test Projesi",
     "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 测试项目(.NET Core)",
+    "name": "NUnit 测试项目",
     "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 測試專案 (.NET Core)",
+    "name": "NUnit 測試專案",
     "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testu NUnit (.NET Core)",
+    "name": "Projekt testu NUnit",
     "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit-Testprojekt (.NET Core)",
+    "name": "NUnit-Testprojekt",
     "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Project (.NET Core)",
+    "name": "NUnit Test Project",
     "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de prueba NUnit (.NET Core)",
+    "name": "Proyecto de prueba NUnit",
     "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test NUnit (.NET Core)",
+    "name": "Projet de test NUnit",
     "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di Test NUnit (.NET Core)",
+    "name": "Progetto di Test NUnit",
     "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit テスト プロジェクト (.NET Core)",
+    "name": "NUnit テスト プロジェクト",
     "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 테스트 프로젝트(.NET Core)",
+    "name": "NUnit 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testowy NUnit (.NET Core)",
+    "name": "Projekt testowy NUnit",
     "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de teste NUnit (.NET Core)",
+    "name": "Projeto de teste NUnit",
     "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Тестовый проект NUnit (.NET Core)",
+    "name": "Тестовый проект NUnit",
     "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Projesi (.NET Core)",
+    "name": "NUnit Test Projesi",
     "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 测试项目(.NET Core)",
+    "name": "NUnit 测试项目",
     "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 測試專案 (.NET Core)",
+    "name": "NUnit 測試專案",
     "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testu NUnit (.NET Core)",
+    "name": "Projekt testu NUnit",
     "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit-Testprojekt (.NET Core)",
+    "name": "NUnit-Testprojekt",
     "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Project (.NET Core)",
+    "name": "NUnit Test Project",
     "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de prueba NUnit (.NET Core)",
+    "name": "Proyecto de prueba NUnit",
     "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test NUnit (.NET Core)",
+    "name": "Projet de test NUnit",
     "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di Test NUnit (.NET Core)",
+    "name": "Progetto di Test NUnit",
     "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit テスト プロジェクト (.NET Core)",
+    "name": "NUnit テスト プロジェクト",
     "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 테스트 프로젝트(.NET Core)",
+    "name": "NUnit 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testowy NUnit (.NET Core)",
+    "name": "Projekt testowy NUnit",
     "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de teste NUnit (.NET Core)",
+    "name": "Projeto de teste NUnit",
     "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Тестовый проект NUnit (.NET Core)",
+    "name": "Тестовый проект NUnit",
     "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Projesi (.NET Core)",
+    "name": "NUnit Test Projesi",
     "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 测试项目(.NET Core)",
+    "name": "NUnit 测试项目",
     "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 測試專案 (.NET Core)",
+    "name": "NUnit 測試專案",
     "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testů xUnit (.NET Core)",
+    "name": "Projekt testů xUnit",
     "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit-Testprojekt (.NET Core)",
+    "name": "xUnit-Testprojekt",
     "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit Test Project (.NET Core)",
+    "name": "xUnit Test Project",
     "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de pruebas xUnit (.NET Core)",
+    "name": "Proyecto de pruebas xUnit",
     "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test xUnit (.NET Core)",
+    "name": "Projet de test xUnit",
     "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di test xUnit (.NET Core)",
+    "name": "Progetto di test xUnit",
     "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit テスト プロジェクト (.NET Core)",
+    "name": "xUnit テスト プロジェクト",
     "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit 테스트 프로젝트(.NET Core)",
+    "name": "xUnit 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testów xUnit (.NET Core)",
+    "name": "Projekt testów xUnit",
     "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de Teste do xUnit (.NET Core)",
+    "name": "Projeto de Teste do xUnit",
     "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Тестовый проект xUnit (.NET Core)",
+    "name": "Тестовый проект xUnit",
     "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit Test Projesi (.NET Core)",
+    "name": "xUnit Test Projesi",
     "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit 测试项目 (.NET Core)",
+    "name": "xUnit 测试项目",
     "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit 測試專案 (.NET Core)",
+    "name": "xUnit 測試專案",
     "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testů xUnit (.NET Core)",
+    "name": "Projekt testů xUnit",
     "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit-Testprojekt (.NET Core)",
+    "name": "xUnit-Testprojekt",
     "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit Test Project (.NET Core)",
+    "name": "xUnit Test Project",
     "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de pruebas xUnit (.NET Core)",
+    "name": "Proyecto de pruebas xUnit",
     "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test xUnit (.NET Core)",
+    "name": "Projet de test xUnit",
     "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di test xUnit (.NET Core)",
+    "name": "Progetto di test xUnit",
     "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit テスト プロジェクト (.NET Core)",
+    "name": "xUnit テスト プロジェクト",
     "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit 테스트 프로젝트(.NET Core)",
+    "name": "xUnit 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testów xUnit (.NET Core)",
+    "name": "Projekt testów xUnit",
     "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de Teste do xUnit (.NET Core)",
+    "name": "Projeto de Teste do xUnit",
     "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Тестовый проект xUnit (.NET Core)",
+    "name": "Тестовый проект xUnit",
     "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit Test Projesi (.NET Core)",
+    "name": "xUnit Test Projesi",
     "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit 测试项目 (.NET Core)",
+    "name": "xUnit 测试项目",
     "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit 測試專案 (.NET Core)",
+    "name": "xUnit 測試專案",
     "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testů xUnit (.NET Core)",
+    "name": "Projekt testů xUnit",
     "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit-Testprojekt (.NET Core)",
+    "name": "xUnit-Testprojekt",
     "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit Test Project (.NET Core)",
+    "name": "xUnit Test Project",
     "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de pruebas xUnit (.NET Core)",
+    "name": "Proyecto de pruebas xUnit",
     "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test xUnit (.NET Core)",
+    "name": "Projet de test xUnit",
     "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di test xUnit (.NET Core)",
+    "name": "Progetto di test xUnit",
     "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit テスト プロジェクト (.NET Core)",
+    "name": "xUnit テスト プロジェクト",
     "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit 테스트 프로젝트(.NET Core)",
+    "name": "xUnit 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testów xUnit (.NET Core)",
+    "name": "Projekt testów xUnit",
     "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de Teste do xUnit (.NET Core)",
+    "name": "Projeto de Teste do xUnit",
     "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Тестовый проект xUnit (.NET Core)",
+    "name": "Тестовый проект xUnit",
     "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit Test Projesi (.NET Core)",
+    "name": "xUnit Test Projesi",
     "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit 测试项目 (.NET Core)",
+    "name": "xUnit 测试项目",
     "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit 測試專案 (.NET Core)",
+    "name": "xUnit 測試專案",
     "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testů MSTest (.NET Core)",
+    "name": "Projekt testů MSTest",
     "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest-Testprojekt (.NET Core)",
+    "name": "MSTest-Testprojekt",
     "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest Test Project (.NET Core)",
+    "name": "MSTest Test Project",
     "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de prueba de MSTest (.NET Core)",
+    "name": "Proyecto de prueba de MSTest",
     "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test MSTest (.NET Core)",
+    "name": "Projet de test MSTest ",
     "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di test MSTest (.NET Core)",
+    "name": "Progetto di test MSTest",
     "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest テスト プロジェクト (.NET Core)",
+    "name": "MSTest テスト プロジェクト",
     "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest 테스트 프로젝트(.NET Core)",
+    "name": "MSTest 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testów MSTest (.NET Core)",
+    "name": "Projekt testów MSTest",
     "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de Teste MSTest (.NET Core)",
+    "name": "Projeto de Teste MSTest",
     "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Проект тестов MSTest (.NET Core)",
+    "name": "Проект тестов MSTest",
     "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Test", "MSTest"],
-  "name": "MSTest Test Project (.NET Core)",
+  "name": "MSTest Test Project",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest Test Projesi (.NET Core)",
+    "name": "MSTest Test Projesi",
     "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest 测试项目(.NET Core)",
+    "name": "MSTest 测试项目",
     "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest 測試專案 (.NET Core)",
+    "name": "MSTest 測試專案",
     "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testů MSTest (.NET Core)",
+    "name": "Projekt testů MSTest",
     "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest-Testprojekt (.NET Core)",
+    "name": "MSTest-Testprojekt",
     "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest Test Project (.NET Core)",
+    "name": "MSTest Test Project",
     "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de prueba de MSTest (.NET Core)",
+    "name": "Proyecto de prueba de MSTest",
     "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test MSTest (.NET Core)",
+    "name": "Projet de test MSTest ",
     "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di test MSTest (.NET Core)",
+    "name": "Progetto di test MSTest",
     "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest テスト プロジェクト (.NET Core)",
+    "name": "MSTest テスト プロジェクト",
     "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest 테스트 프로젝트(.NET Core)",
+    "name": "MSTest 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testów MSTest (.NET Core)",
+    "name": "Projekt testów MSTest",
     "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de Teste MSTest (.NET Core)",
+    "name": "Projeto de Teste MSTest",
     "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Проект тестов MSTest (.NET Core)",
+    "name": "Проект тестов MSTest",
     "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Test", "MSTest"],
-  "name": "MSTest Test Project (.NET Core)",
+  "name": "MSTest Test Project",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest Test Projesi (.NET Core)",
+    "name": "MSTest Test Projesi",
     "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest 测试项目(.NET Core)",
+    "name": "MSTest 测试项目",
     "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest 測試專案 (.NET Core)",
+    "name": "MSTest 測試專案",
     "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testů MSTest (.NET Core)",
+    "name": "Projekt testů MSTest",
     "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest-Testprojekt (.NET Core)",
+    "name": "MSTest-Testprojekt",
     "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest Test Project (.NET Core)",
+    "name": "MSTest Test Project",
     "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de prueba de MSTest (.NET Core)",
+    "name": "Proyecto de prueba de MSTest",
     "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test MSTest (.NET Core)",
+    "name": "Projet de test MSTest ",
     "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di test MSTest (.NET Core)",
+    "name": "Progetto di test MSTest",
     "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest テスト プロジェクト (.NET Core)",
+    "name": "MSTest テスト プロジェクト",
     "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest 테스트 프로젝트(.NET Core)",
+    "name": "MSTest 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testów MSTest (.NET Core)",
+    "name": "Projekt testów MSTest",
     "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de Teste MSTest (.NET Core)",
+    "name": "Projeto de Teste MSTest",
     "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Проект тестов MSTest (.NET Core)",
+    "name": "Проект тестов MSTest",
     "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Test", "MSTest"],
-  "name": "MSTest Test Project (.NET Core)",
+  "name": "MSTest Test Project",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest Test Projesi (.NET Core)",
+    "name": "MSTest Test Projesi",
     "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest 测试项目(.NET Core)",
+    "name": "MSTest 测试项目",
     "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "MSTest 測試專案 (.NET Core)",
+    "name": "MSTest 測試專案",
     "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testu NUnit (.NET Core)",
+    "name": "Projekt testu NUnit",
     "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit-Testprojekt (.NET Core)",
+    "name": "NUnit-Testprojekt",
     "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Project (.NET Core)",
+    "name": "NUnit Test Project",
     "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de prueba NUnit (.NET Core)",
+    "name": "Proyecto de prueba NUnit",
     "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test NUnit (.NET Core)",
+    "name": "Projet de test NUnit",
     "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di Test NUnit (.NET Core)",
+    "name": "Progetto di Test NUnit",
     "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit テスト プロジェクト (.NET Core)",
+    "name": "NUnit テスト プロジェクト",
     "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 테스트 프로젝트(.NET Core)",
+    "name": "NUnit 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testowy NUnit (.NET Core)",
+    "name": "Projekt testowy NUnit",
     "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de teste NUnit (.NET Core)",
+    "name": "Projeto de teste NUnit",
     "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Тестовый проект NUnit (.NET Core)",
+    "name": "Тестовый проект NUnit",
     "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Projesi (.NET Core)",
+    "name": "NUnit Test Projesi",
     "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 测试项目(.NET Core)",
+    "name": "NUnit 测试项目",
     "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 測試專案 (.NET Core)",
+    "name": "NUnit 測試專案",
     "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testu NUnit (.NET Core)",
+    "name": "Projekt testu NUnit",
     "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit-Testprojekt (.NET Core)",
+    "name": "NUnit-Testprojekt",
     "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Project (.NET Core)",
+    "name": "NUnit Test Project",
     "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de prueba NUnit (.NET Core)",
+    "name": "Proyecto de prueba NUnit",
     "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test NUnit (.NET Core)",
+    "name": "Projet de test NUnit",
     "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di Test NUnit (.NET Core)",
+    "name": "Progetto di Test NUnit",
     "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit テスト プロジェクト (.NET Core)",
+    "name": "NUnit テスト プロジェクト",
     "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 테스트 프로젝트(.NET Core)",
+    "name": "NUnit 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testowy NUnit (.NET Core)",
+    "name": "Projekt testowy NUnit",
     "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de teste NUnit (.NET Core)",
+    "name": "Projeto de teste NUnit",
     "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Тестовый проект NUnit (.NET Core)",
+    "name": "Тестовый проект NUnit",
     "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Projesi (.NET Core)",
+    "name": "NUnit Test Projesi",
     "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 测试项目(.NET Core)",
+    "name": "NUnit 测试项目",
     "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 測試專案 (.NET Core)",
+    "name": "NUnit 測試專案",
     "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testu NUnit (.NET Core)",
+    "name": "Projekt testu NUnit",
     "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit-Testprojekt (.NET Core)",
+    "name": "NUnit-Testprojekt",
     "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Project (.NET Core)",
+    "name": "NUnit Test Project",
     "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de prueba NUnit (.NET Core)",
+    "name": "Proyecto de prueba NUnit",
     "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test NUnit (.NET Core)",
+    "name": "Projet de test NUnit",
     "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di Test NUnit (.NET Core)",
+    "name": "Progetto di Test NUnit",
     "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit テスト プロジェクト (.NET Core)",
+    "name": "NUnit テスト プロジェクト",
     "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 테스트 프로젝트(.NET Core)",
+    "name": "NUnit 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testowy NUnit (.NET Core)",
+    "name": "Projekt testowy NUnit",
     "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de teste NUnit (.NET Core)",
+    "name": "Projeto de teste NUnit",
     "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Тестовый проект NUnit (.NET Core)",
+    "name": "Тестовый проект NUnit",
     "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Projesi (.NET Core)",
+    "name": "NUnit Test Projesi",
     "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 测试项目(.NET Core)",
+    "name": "NUnit 测试项目",
     "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 測試專案 (.NET Core)",
+    "name": "NUnit 測試專案",
     "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testu NUnit (.NET Core)",
+    "name": "Projekt testu NUnit",
     "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit-Testprojekt (.NET Core)",
+    "name": "NUnit-Testprojekt",
     "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Project (.NET Core)",
+    "name": "NUnit Test Project",
     "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de prueba NUnit (.NET Core)",
+    "name": "Proyecto de prueba NUnit",
     "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test NUnit (.NET Core)",
+    "name": "Projet de test NUnit",
     "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di Test NUnit (.NET Core)",
+    "name": "Progetto di Test NUnit",
     "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit テスト プロジェクト (.NET Core)",
+    "name": "NUnit テスト プロジェクト",
     "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 테스트 프로젝트(.NET Core)",
+    "name": "NUnit 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testowy NUnit (.NET Core)",
+    "name": "Projekt testowy NUnit",
     "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de teste NUnit (.NET Core)",
+    "name": "Projeto de teste NUnit",
     "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Тестовый проект NUnit (.NET Core)",
+    "name": "Тестовый проект NUnit",
     "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Projesi (.NET Core)",
+    "name": "NUnit Test Projesi",
     "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 测试项目(.NET Core)",
+    "name": "NUnit 测试项目",
     "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 測試專案 (.NET Core)",
+    "name": "NUnit 測試專案",
     "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testu NUnit (.NET Core)",
+    "name": "Projekt testu NUnit",
     "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit-Testprojekt (.NET Core)",
+    "name": "NUnit-Testprojekt",
     "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Project (.NET Core)",
+    "name": "NUnit Test Project",
     "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de prueba NUnit (.NET Core)",
+    "name": "Proyecto de prueba NUnit",
     "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test NUnit (.NET Core)",
+    "name": "Projet de test NUnit",
     "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di Test NUnit (.NET Core)",
+    "name": "Progetto di Test NUnit",
     "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit テスト プロジェクト (.NET Core)",
+    "name": "NUnit テスト プロジェクト",
     "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 테스트 프로젝트(.NET Core)",
+    "name": "NUnit 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testowy NUnit (.NET Core)",
+    "name": "Projekt testowy NUnit",
     "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de teste NUnit (.NET Core)",
+    "name": "Projeto de teste NUnit",
     "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Тестовый проект NUnit (.NET Core)",
+    "name": "Тестовый проект NUnit",
     "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Projesi (.NET Core)",
+    "name": "NUnit Test Projesi",
     "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 测试项目(.NET Core)",
+    "name": "NUnit 测试项目",
     "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 測試專案 (.NET Core)",
+    "name": "NUnit 測試專案",
     "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testu NUnit (.NET Core)",
+    "name": "Projekt testu NUnit",
     "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit-Testprojekt (.NET Core)",
+    "name": "NUnit-Testprojekt",
     "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Project (.NET Core)",
+    "name": "NUnit Test Project",
     "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de prueba NUnit (.NET Core)",
+    "name": "Proyecto de prueba NUnit",
     "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test NUnit (.NET Core)",
+    "name": "Projet de test NUnit",
     "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di Test NUnit (.NET Core)",
+    "name": "Progetto di Test NUnit",
     "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit テスト プロジェクト (.NET Core)",
+    "name": "NUnit テスト プロジェクト",
     "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 테스트 프로젝트(.NET Core)",
+    "name": "NUnit 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testowy NUnit (.NET Core)",
+    "name": "Projekt testowy NUnit",
     "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de teste NUnit (.NET Core)",
+    "name": "Projeto de teste NUnit",
     "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Тестовый проект NUnit (.NET Core)",
+    "name": "Тестовый проект NUnit",
     "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit Test Projesi (.NET Core)",
+    "name": "NUnit Test Projesi",
     "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 测试项目(.NET Core)",
+    "name": "NUnit 测试项目",
     "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "NUnit 測試專案 (.NET Core)",
+    "name": "NUnit 測試專案",
     "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testů xUnit (.NET Core)",
+    "name": "Projekt testů xUnit",
     "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit-Testprojekt (.NET Core)",
+    "name": "xUnit-Testprojekt",
     "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit Test Project (.NET Core)",
+    "name": "xUnit Test Project",
     "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de pruebas xUnit (.NET Core)",
+    "name": "Proyecto de pruebas xUnit",
     "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test xUnit (.NET Core)",
+    "name": "Projet de test xUnit",
     "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di test xUnit (.NET Core)",
+    "name": "Progetto di test xUnit",
     "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit テスト プロジェクト (.NET Core)",
+    "name": "xUnit テスト プロジェクト",
     "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit 테스트 프로젝트(.NET Core)",
+    "name": "xUnit 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testów xUnit (.NET Core)",
+    "name": "Projekt testów xUnit",
     "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de Teste do xUnit (.NET Core)",
+    "name": "Projeto de Teste do xUnit",
     "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Тестовый проект xUnit (.NET Core)",
+    "name": "Тестовый проект xUnit",
     "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit Test Projesi (.NET Core)",
+    "name": "xUnit Test Projesi",
     "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit 测试项目 (.NET Core)",
+    "name": "xUnit 测试项目",
     "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit 測試專案 (.NET Core)",
+    "name": "xUnit 測試專案",
     "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testů xUnit (.NET Core)",
+    "name": "Projekt testů xUnit",
     "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit-Testprojekt (.NET Core)",
+    "name": "xUnit-Testprojekt",
     "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit Test Project (.NET Core)",
+    "name": "xUnit Test Project",
     "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de pruebas xUnit (.NET Core)",
+    "name": "Proyecto de pruebas xUnit",
     "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test xUnit (.NET Core)",
+    "name": "Projet de test xUnit",
     "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di test xUnit (.NET Core)",
+    "name": "Progetto di test xUnit",
     "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit テスト プロジェクト (.NET Core)",
+    "name": "xUnit テスト プロジェクト",
     "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit 테스트 프로젝트(.NET Core)",
+    "name": "xUnit 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testów xUnit (.NET Core)",
+    "name": "Projekt testów xUnit",
     "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de Teste do xUnit (.NET Core)",
+    "name": "Projeto de Teste do xUnit",
     "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Тестовый проект xUnit (.NET Core)",
+    "name": "Тестовый проект xUnit",
     "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit Test Projesi (.NET Core)",
+    "name": "xUnit Test Projesi",
     "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit 测试项目 (.NET Core)",
+    "name": "xUnit 测试项目",
     "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit 測試專案 (.NET Core)",
+    "name": "xUnit 測試專案",
     "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/cs-CZ/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testů xUnit (.NET Core)",
+    "name": "Projekt testů xUnit",
     "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/de-DE/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit-Testprojekt (.NET Core)",
+    "name": "xUnit-Testprojekt",
     "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/en-US/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit Test Project (.NET Core)",
+    "name": "xUnit Test Project",
     "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/es-ES/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Proyecto de pruebas xUnit (.NET Core)",
+    "name": "Proyecto de pruebas xUnit",
     "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/fr-FR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projet de test xUnit (.NET Core)",
+    "name": "Projet de test xUnit",
     "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/it-IT/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Progetto di test xUnit (.NET Core)",
+    "name": "Progetto di test xUnit",
     "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/ja-JP/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit テスト プロジェクト (.NET Core)",
+    "name": "xUnit テスト プロジェクト",
     "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/ko-KR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit 테스트 프로젝트(.NET Core)",
+    "name": "xUnit 테스트 프로젝트",
     "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/pl-PL/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projekt testów xUnit (.NET Core)",
+    "name": "Projekt testów xUnit",
     "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/pt-BR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Projeto de Teste do xUnit (.NET Core)",
+    "name": "Projeto de Teste do xUnit",
     "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/ru-RU/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Тестовый проект xUnit (.NET Core)",
+    "name": "Тестовый проект xUnit",
     "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/tr-TR/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit Test Projesi (.NET Core)",
+    "name": "xUnit Test Projesi",
     "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/zh-CN/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit 测试项目 (.NET Core)",
+    "name": "xUnit 测试项目",
     "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/zh-TW/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "xUnit 測試專案 (.NET Core)",
+    "name": "xUnit 測試專案",
     "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
   }
 }


### PR DESCRIPTION
Removing the word ".NET Core" from template names for .NET 5.0 and .NET 6.0