### PR TITLE
Updated nunit with adapter templates

### DIFF
--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/Company.TestProject1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0"  />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="coverlet.collector" Version="3.0.3" />

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/Company.TestProject1.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/Company.TestProject1.fsproj
@@ -16,10 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/Company.TestProject1.vbproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/NUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/NUnit-CSharp/Company.TestProject1.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/NUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/NUnit-FSharp/Company.TestProject1.fsproj
@@ -16,10 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/NUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/NUnit-CSharp/Company.TestProject1.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/NUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/NUnit-FSharp/Company.TestProject1.fsproj
@@ -16,10 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/NUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/NUnit-VisualBasic/Company.TestProject1.vbproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/Company.TestProject1.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/Company.TestProject1.fsproj
@@ -16,10 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/Company.TestProject1.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/Company.TestProject1.fsproj
@@ -16,10 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The test templates for NUnit has been updated.  The NUnit3TestAdapter has been updated to version 4.0.0, required for VS2022.  NUnit has been updated to 3.13.2,  the sdk and coverlet have been adjusted to current latest.