### PR TITLE
Fix incorrect casing in 6.0 project template csproj

### DIFF
--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/Microsoft.DotNet.Test.ProjectTemplates.6.0.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/Microsoft.DotNet.Test.ProjectTemplates.6.0.csproj
@@ -24,7 +24,7 @@
         <PackageReference Remove="Microsoft.NETCore.App" />
         <Compile Remove="$(GitInfoFile)" />
         <Compile Remove="$(MSBuildThisFileDirectory)../../src/GitInfo.cs" />
-        <Content Include="Content\**">
+        <Content Include="content\**">
             <PackagePath>content</PackagePath>
         </Content>
     </ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/test-templates/issues/186.