### PR TITLE
Switch to 1ES R&D pools on main

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,11 +33,11 @@ stages:
           # For public or PR jobs, use the hosted pool.  For internal jobs use the internal pool.
           # Will eventually change this to two BYOC pools.
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-            name: NetCorePublic-Pool
-            queue: buildpool.windows.10.amd64.vs2019.pre.open
+            name: NetCore1ESPool-Public
+            demands: ImageOverride -equals build.windows.10.amd64.vs2019.pre.open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            name: NetCoreInternal-Pool
-            queue: buildpool.windows.10.amd64.vs2019.pre
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals build.windows.10.amd64.vs2019.pre
         variables:
         - _OfficialBuildArgs: ''
         # Only enable publishing in official builds.


### PR DESCRIPTION
We need to migrate to the new 1ES hosted pools. This does that on `main`.

cc/ @ulisesh @lpatalas 