### PR TITLE
Added ImplicitUsings=enable to csproj templates

### DIFF
--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -4,6 +4,7 @@
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net6.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
     <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/Company.TestProject1.csproj
@@ -4,6 +4,7 @@
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net6.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
     <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/Company.TestProject1.csproj
@@ -4,6 +4,7 @@
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net6.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
     <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>


### PR DESCRIPTION
I considered copying the pattern from the classlib definition whereby
there is language version checking around whether to include the
additional parameter, but I decided to follow the pattern established by
the Nullable=enable and just hard code it to always be present.