### PR TITLE
Make 'using' declarations global

### DIFF
--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/template.json
@@ -58,6 +58,10 @@
     {
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "path": "UnitTest1.cs"
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "Usings.cs"
     }
   ],
   "defaultName": "TestProject1",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/UnitTest1.cs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/UnitTest1.cs
@@ -1,5 +1,3 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
 namespace Company.TestProject1;
 
 [TestClass]

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/Usings.cs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/Usings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/template.json
@@ -59,6 +59,10 @@
     {
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "path": "UnitTest1.cs"
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "Usings.cs"
     }
   ],
   "defaultName": "TestProject1",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/UnitTest1.cs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/UnitTest1.cs
@@ -1,5 +1,3 @@
-using NUnit.Framework;
-
 namespace Company.TestProject1;
 
 public class Tests

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/Usings.cs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/Usings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/template.json
@@ -58,6 +58,10 @@
     {
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "path": "UnitTest1.cs"
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "Usings.cs"
     }
   ],
   "defaultName": "TestProject1",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/UnitTest1.cs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/UnitTest1.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace Company.TestProject1;
 
 public class UnitTest1

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/Usings.cs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;


### PR DESCRIPTION
One of C# 10's new features is the 'global using'. This enables a single
'using' to be applied to all source code files within a project. Given
that these are test projects, it is likely that the majority of source
code files within them will require inclusion of a reference to the test
framework. Therefore it seems like these particular usings are excellent
candidates to be made global.