### PR TITLE
Enable template localization on dotnet CLI

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,7 +4,7 @@
     <clear />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="dotnet5-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="test-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/Microsoft.DotNet.Test.ProjectTemplates.2.1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/Microsoft.DotNet.Test.ProjectTemplates.2.1.csproj
@@ -4,6 +4,7 @@
         <IncludeBuildOutput>False</IncludeBuildOutput>
         <IncludeSource>False</IncludeSource>
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+        <UsingToolTemplateLocalizer>true</UsingToolTemplateLocalizer>
         <OutputPath>$(TemplatesFolder)</OutputPath>
         <EnableDefaultItems>False</EnableDefaultItems>
         <IsPackable>true</IsPackable>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/.template.config/template.json
@@ -69,6 +69,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -76,6 +77,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/.template.config/template.json
@@ -69,6 +69,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -76,6 +77,7 @@
       "description": "Opens Tests.fs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "MSTest Test Project (.NET Core)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/.template.config/template.json
@@ -69,6 +69,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -76,6 +77,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp-Item/.template.config/template.json
@@ -24,6 +24,7 @@
       "description": "Opens created test fixture class in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "0"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-CSharp/.template.config/template.json
@@ -69,6 +69,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -76,6 +77,7 @@
       "description": "Opens UnitTest1.cs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp-Item/.template.config/template.json
@@ -24,6 +24,7 @@
       "description": "Opens created test fixture class in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "0"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-FSharp/.template.config/template.json
@@ -69,6 +69,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -76,6 +77,7 @@
       "description": "Opens UnitTest1.fs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Item",
+  "description": "A item that contains NUnit tests",
+  "postActions/openInEditor/description": "Opens created test fixture class in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic-Item/.template.config/template.json
@@ -24,6 +24,7 @@
       "description": "Opens created test fixture class in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "0"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.vb in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.vb in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.vb in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.vb in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.vb in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.vb in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.vb in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.vb in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.vb in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.vb in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.vb in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.vb in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.vb in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,13 @@
+{
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "name": "NUnit 3 Test Project",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens UnitTest1.vb in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/NUnit-VisualBasic/.template.config/template.json
@@ -69,6 +69,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -76,6 +77,7 @@
       "description": "Opens UnitTest1.vb in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/.template.config/template.json
@@ -69,6 +69,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -76,6 +77,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Tests.fs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/.template.config/template.json
@@ -69,6 +69,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -76,6 +77,7 @@
       "description": "Opens Tests.fs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,13 @@
+{
+  "author": "Microsoft",
+  "name": "xUnit Test Project",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp2.1/description": "Target netcoreapp2.1",
+  "symbols/EnablePack/description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project.",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
+  "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor"
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/.template.config/template.json
@@ -69,6 +69,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -76,6 +77,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/MSTest-CSharp/.template.config/template.json
@@ -69,6 +69,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -76,6 +77,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/MSTest-FSharp/.template.config/template.json
@@ -69,6 +69,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -76,6 +77,7 @@
       "description": "Opens Tests.fs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -69,6 +69,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -76,6 +77,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/NUnit-CSharp-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/NUnit-CSharp-Item/.template.config/template.json
@@ -24,6 +24,7 @@
       "description": "Opens created test fixture class in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "0"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/NUnit-CSharp/.template.config/template.json
@@ -70,6 +70,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -77,6 +78,7 @@
       "description": "Opens UnitTest1.cs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/NUnit-FSharp-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/NUnit-FSharp-Item/.template.config/template.json
@@ -24,6 +24,7 @@
       "description": "Opens created test fixture class in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "0"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/NUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/NUnit-FSharp/.template.config/template.json
@@ -70,6 +70,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -77,6 +78,7 @@
       "description": "Opens UnitTest1.fs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/NUnit-VisualBasic-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/NUnit-VisualBasic-Item/.template.config/template.json
@@ -24,6 +24,7 @@
       "description": "Opens created test fixture class in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "0"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/NUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/NUnit-VisualBasic/.template.config/template.json
@@ -70,6 +70,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -77,6 +78,7 @@
       "description": "Opens UnitTest1.vb in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/XUnit-CSharp/.template.config/template.json
@@ -69,6 +69,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -76,6 +77,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/XUnit-FSharp/.template.config/template.json
@@ -69,6 +69,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -76,6 +77,7 @@
       "description": "Opens Tests.fs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/XUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/XUnit-VisualBasic/.template.config/template.json
@@ -69,6 +69,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -76,6 +77,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/MSTest-CSharp/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/MSTest-FSharp/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Tests.fs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/MSTest-VisualBasic/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/NUnit-CSharp-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/NUnit-CSharp-Item/.template.config/template.json
@@ -24,6 +24,7 @@
       "description": "Opens created test fixture class in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "0"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/NUnit-CSharp/.template.config/template.json
@@ -70,6 +70,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -77,6 +78,7 @@
       "description": "Opens UnitTest1.cs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/NUnit-FSharp-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/NUnit-FSharp-Item/.template.config/template.json
@@ -24,6 +24,7 @@
       "description": "Opens created test fixture class in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "0"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/NUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/NUnit-FSharp/.template.config/template.json
@@ -70,6 +70,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -77,6 +78,7 @@
       "description": "Opens UnitTest1.fs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/NUnit-VisualBasic-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/NUnit-VisualBasic-Item/.template.config/template.json
@@ -24,6 +24,7 @@
       "description": "Opens created test fixture class in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "0"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/NUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/NUnit-VisualBasic/.template.config/template.json
@@ -70,6 +70,7 @@
         { "text": "Run 'dotnet restore'" }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -77,6 +78,7 @@
       "description": "Opens UnitTest1.vb in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/XUnit-CSharp/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/XUnit-FSharp/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Tests.fs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/XUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.1/content/XUnit-VisualBasic/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [ { "text": "Run 'dotnet restore'" } ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Tests.fs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/template.json
@@ -24,6 +24,7 @@
       "description": "Opens created test fixture class in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "0"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/template.json
@@ -68,6 +68,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -75,6 +76,7 @@
       "description": "Opens UnitTest1.cs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/template.json
@@ -24,6 +24,7 @@
       "description": "Opens created test fixture class in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "0"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/template.json
@@ -68,6 +68,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -75,6 +76,7 @@
       "description": "Opens UnitTest1.fs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/template.json
@@ -24,6 +24,7 @@
       "description": "Opens created test fixture class in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "0"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/template.json
@@ -68,6 +68,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -75,6 +76,7 @@
       "description": "Opens UnitTest1.vb in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Tests.fs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/template.json
@@ -71,6 +71,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -78,6 +79,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Tests.fs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/template.json
@@ -24,6 +24,7 @@
       "description": "Opens created test fixture class in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "0"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/template.json
@@ -72,6 +72,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -79,6 +80,7 @@
       "description": "Opens UnitTest1.cs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/template.json
@@ -24,6 +24,7 @@
       "description": "Opens created test fixture class in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "0"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/template.json
@@ -68,6 +68,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -75,6 +76,7 @@
       "description": "Opens UnitTest1.fs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/template.json
@@ -24,6 +24,7 @@
       "description": "Opens created test fixture class in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "0"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/template.json
@@ -68,6 +68,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -75,6 +76,7 @@
       "description": "Opens UnitTest1.vb in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/template.json
@@ -71,6 +71,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -78,6 +79,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Tests.fs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/template.json
@@ -71,6 +71,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -78,6 +79,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Tests.fs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/template.json
@@ -24,6 +24,7 @@
       "description": "Opens created test fixture class in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "0"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/template.json
@@ -72,6 +72,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -79,6 +80,7 @@
       "description": "Opens UnitTest1.cs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/template.json
@@ -24,6 +24,7 @@
       "description": "Opens created test fixture class in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "0"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/template.json
@@ -68,6 +68,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -75,6 +76,7 @@
       "description": "Opens UnitTest1.fs in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/template.json
@@ -24,6 +24,7 @@
       "description": "Opens created test fixture class in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "0"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/template.json
@@ -68,6 +68,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -75,6 +76,7 @@
       "description": "Opens UnitTest1.vb in the editor",
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/template.json
@@ -71,6 +71,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -78,6 +79,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Tests.fs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/template.json
@@ -67,6 +67,7 @@
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
       "continueOnError": true
     },
     {
@@ -74,6 +75,7 @@
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
       "args": {
         "files": "1"
       },


### PR DESCRIPTION
## Background:
 Template engine (`dotnet new`) added support for template localizations in .NET 6.0. This new system replaces the old way of localizing templates that only worked on Visual Studio and works on both .NET CLI as well as VS.

This PR introduces changes to switch to the new template localization system.

## Summary of the changes
- Adds dotnet7 feed
- Adds `<UsingToolTemplateLocalizer>true</>` to projects containing templates.
- Adds necessary `id` fields into `template.json` files to allow localizing certain fields (specifically, post actions) - by regex/replace.
- Generates localization files to be translated by loc team.

## What to expect after merging
Every time there is a change to one of the templates:
- The dev making the change should build (at the very least) the modified template project. This will update the loc files on the local working copy,
- Push the loc files together with the template modifications. Review & merge.
- OneLocBuild integration will automatically pick up the changes and will send them for translation.
- You will receive a PR containing the translated template loc files when they are ready. Review & merge.