### PR TITLE
Add net8 templates

### DIFF
--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -18,7 +18,7 @@ function InitializeCustomSDKToolset {
     "3.1.0"
     "5.0.1"
     "6.0.1"
-    "7.0.100-rc.2.22454.1"
+    "7.0.0-rc.1.22422.12"
     # version from global.json (8.0.0) will be installed automatically
   )
 

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -18,7 +18,7 @@ function InitializeCustomSDKToolset {
     "3.1.0"
     "5.0.1"
     "6.0.1"
-    "7.0.0-rc.1.22422.12"
+    "7.0.0-rc.1.22426.10"
     # version from global.json (8.0.0) will be installed automatically
   )
 

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -23,7 +23,8 @@ function InitializeCustomSDKToolset {
     "3.1.0"
     "5.0.1"
     "6.0.1"
-    # version from global.json (7.0.0) will be installed automatically
+    "7.0.100-rc.2.22454.1"
+    # version from global.json (8.0.0) will be installed automatically
   )
 
   foreach ($version in $versions) {

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -15,11 +15,6 @@ function InitializeCustomSDKToolset {
   $installScript = GetDotNetInstallScript $dotnetRoot
 
   $versions = @(
-    "1.0.5"
-    "1.1.2"
-    "2.1.0"
-    "2.2.1"
-    "2.2.2"
     "3.1.0"
     "5.0.1"
     "6.0.1"

--- a/global.json
+++ b/global.json
@@ -8,12 +8,12 @@
         "5.0.12"
       ]
     },
-    "dotnet": "7.0.100-preview.7.22377.5"
+    "dotnet": "8.0.100-alpha.1.22453.1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22419.1"
   },
   "sdk": {
-    "version": "7.0.100-preview.7.22377.5"
+    "version": "8.0.100-alpha.1.22453.1"
   }
 }

--- a/global.json
+++ b/global.json
@@ -8,12 +8,12 @@
         "5.0.12"
       ]
     },
-    "dotnet": "8.0.100-alpha.1.22453.1"
+    "dotnet": "8.0.100-alpha.1.22470.29"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22419.1"
   },
   "sdk": {
-    "version": "8.0.100-alpha.1.22453.1"
+    "version": "8.0.100-alpha.1.22470.29"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů MSTest",
-    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
+    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET ve Windows, Linuxu a MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest-Testprojekt",
-    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
+    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET unter Windows, Linux und MacOS ausgeführt werden."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Project",
-    "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba de MSTest",
-    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test MSTest ",
-    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test MSTest",
-    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest テスト プロジェクト",
-    "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
+    "description": "Windows、Linux、MacOS 上の .NET で実行できる MSTest 単体テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów MSTest",
-    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste MSTest",
-    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET no Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Проект тестов MSTest",
-    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": [ "Test", "MSTest" ],
   "name": "MSTest Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",
   "precedence": "7000",
   "identity": "Microsoft.Test.MSTest.CSharp.5.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Projesi",
-    "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS'ta .NET üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 测试项目",
-    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
+    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-CSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 測試專案",
-    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
+    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET 上執行的 MSTest 單元測試。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů MSTest",
-    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
+    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET ve Windows, Linuxu a MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest-Testprojekt",
-    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
+    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET unter Windows, Linux und MacOS ausgeführt werden."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Project",
-    "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba de MSTest",
-    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test MSTest ",
-    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test MSTest",
-    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest テスト プロジェクト",
-    "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
+    "description": "Windows、Linux、MacOS 上の .NET で実行できる MSTest 単体テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów MSTest",
-    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste MSTest",
-    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET no Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Проект тестов MSTest",
-    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "MSTest"],
   "name": "MSTest Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",
   "precedence": "7000",
   "identity": "Microsoft.Test.MSTest.FSharp.5.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Projesi",
-    "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS'ta .NET üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 测试项目",
-    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
+    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-FSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 測試專案",
-    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
+    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET 上執行的 MSTest 單元測試。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů MSTest",
-    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
+    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET ve Windows, Linuxu a MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest-Testprojekt",
-    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
+    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET unter Windows, Linux und MacOS ausgeführt werden."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Project",
-    "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba de MSTest",
-    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test MSTest ",
-    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test MSTest",
-    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest テスト プロジェクト",
-    "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
+    "description": "Windows、Linux、MacOS 上の .NET で実行できる MSTest 単体テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów MSTest",
-    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste MSTest",
-    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET no Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Проект тестов MSTest",
-    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "MSTest"],
   "name": "MSTest Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",
   "precedence": "7000",
   "identity": "Microsoft.Test.MSTest.VisualBasic.5.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Projesi",
-    "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS'ta .NET üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 测试项目",
-    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
+    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/MSTest-VisualBasic/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 測試專案",
-    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
+    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET 上執行的 MSTest 單元測試。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp-Item/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/template.json
@@ -5,7 +5,7 @@
   "name": "NUnit 3 Test Project",
   "defaultName": "NUnitTestProject",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
   "precedence": "7000",
   "identity": "NUnit3.DotNetNew.Template.CSharp.5.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-CSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp-Item/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/template.json
@@ -5,7 +5,7 @@
   "name": "NUnit 3 Test Project",
   "defaultName": "NUnitTestProject",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
   "precedence": "7000",
   "identity": "NUnit3.DotNetNew.Template.FSharp.5.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-FSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic-Item/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/template.json
@@ -5,7 +5,7 @@
   "name": "NUnit 3 Test Project",
   "defaultName": "NUnitTestProject",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
   "precedence": "7000",
   "identity": "NUnit3.DotNetNew.Template.VisualBasic.5.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/NUnit-VisualBasic/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů xUnit",
-    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
+    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET ve Windows, Linuxu a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit-Testprojekt",
-    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Project",
-    "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de pruebas xUnit",
-    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test xUnit",
-    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test xUnit",
-    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit テスト プロジェクト",
-    "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
+    "description": "Windows、Linux、および MacOS 上の .NET で実行できる xUnit.net テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów xUnit",
-    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste do xUnit",
-    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET em Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект xUnit",
-    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "xUnit"],
   "name": "xUnit Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
   "precedence": "7000",
   "identity": "Microsoft.Test.xUnit.CSharp.5.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS’ta .NET üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 测试项目",
-    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
+    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET 上运行"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-CSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 測試專案",
-    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
+    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET 上執行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů xUnit",
-    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
+    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET ve Windows, Linuxu a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit-Testprojekt",
-    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Project",
-    "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de pruebas xUnit",
-    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test xUnit",
-    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test xUnit",
-    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit テスト プロジェクト",
-    "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
+    "description": "Windows、Linux、および MacOS 上の .NET で実行できる xUnit.net テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów xUnit",
-    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste do xUnit",
-    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET em Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект xUnit",
-    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "xUnit"],
   "name": "xUnit Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
   "precedence": "7000",
   "identity": "Microsoft.Test.xUnit.FSharp.5.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS’ta .NET üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 测试项目",
-    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
+    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET 上运行"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-FSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 測試專案",
-    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
+    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET 上執行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů xUnit",
-    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
+    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET ve Windows, Linuxu a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit-Testprojekt",
-    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Project",
-    "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de pruebas xUnit",
-    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test xUnit",
-    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test xUnit",
-    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit テスト プロジェクト",
-    "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
+    "description": "Windows、Linux、および MacOS 上の .NET で実行できる xUnit.net テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów xUnit",
-    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste do xUnit",
-    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET em Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект xUnit",
-    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "xUnit"],
   "name": "xUnit Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
   "precedence": "7000",
   "identity": "Microsoft.Test.xUnit.VisualBasic.5.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS’ta .NET üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 测试项目",
-    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
+    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET 上运行"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.5.0/content/XUnit-VisualBasic/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 測試專案",
-    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
+    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET 上執行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů MSTest",
-    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
+    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET ve Windows, Linuxu a MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest-Testprojekt",
-    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
+    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET unter Windows, Linux und MacOS ausgeführt werden."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Project",
-    "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba de MSTest",
-    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test MSTest ",
-    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test MSTest",
-    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest テスト プロジェクト",
-    "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
+    "description": "Windows、Linux、MacOS 上の .NET で実行できる MSTest 単体テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów MSTest",
-    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste MSTest",
-    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET no Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Проект тестов MSTest",
-    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "MSTest"],
   "name": "MSTest Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",
   "precedence": "8000",
   "identity": "Microsoft.Test.MSTest.CSharp.6.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Projesi",
-    "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS'ta .NET üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 测试项目",
-    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
+    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-CSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 測試專案",
-    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
+    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET 上執行的 MSTest 單元測試。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů MSTest",
-    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
+    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET ve Windows, Linuxu a MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest-Testprojekt",
-    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
+    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET unter Windows, Linux und MacOS ausgeführt werden."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Project",
-    "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba de MSTest",
-    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test MSTest ",
-    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test MSTest",
-    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest テスト プロジェクト",
-    "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
+    "description": "Windows、Linux、MacOS 上の .NET で実行できる MSTest 単体テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów MSTest",
-    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste MSTest",
-    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET no Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Проект тестов MSTest",
-    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "MSTest"],
   "name": "MSTest Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",
   "precedence": "8000",
   "identity": "Microsoft.Test.MSTest.FSharp.6.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Projesi",
-    "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS'ta .NET üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 测试项目",
-    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
+    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-FSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 測試專案",
-    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
+    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET 上執行的 MSTest 單元測試。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů MSTest",
-    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
+    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET ve Windows, Linuxu a MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest-Testprojekt",
-    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
+    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET unter Windows, Linux und MacOS ausgeführt werden."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Project",
-    "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba de MSTest",
-    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test MSTest ",
-    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test MSTest",
-    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest テスト プロジェクト",
-    "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
+    "description": "Windows、Linux、MacOS 上の .NET で実行できる MSTest 単体テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów MSTest",
-    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste MSTest",
-    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET no Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Проект тестов MSTest",
-    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "MSTest"],
   "name": "MSTest Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",
   "precedence": "8000",
   "identity": "Microsoft.Test.MSTest.VisualBasic.6.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Projesi",
-    "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS'ta .NET üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 测试项目",
-    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
+    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/MSTest-VisualBasic/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 測試專案",
-    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
+    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET 上執行的 MSTest 單元測試。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp-Item/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/template.json
@@ -5,7 +5,7 @@
   "name": "NUnit 3 Test Project",
   "defaultName": "NUnitTestProject",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
   "precedence": "8000",
   "identity": "NUnit3.DotNetNew.Template.CSharp.6.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-CSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp-Item/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/template.json
@@ -5,7 +5,7 @@
   "name": "NUnit 3 Test Project",
   "defaultName": "NUnitTestProject",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
   "precedence": "8000",
   "identity": "NUnit3.DotNetNew.Template.FSharp.6.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-FSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic-Item/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/template.json
@@ -5,7 +5,7 @@
   "name": "NUnit 3 Test Project",
   "defaultName": "NUnitTestProject",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
   "precedence": "8000",
   "identity": "NUnit3.DotNetNew.Template.VisualBasic.6.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/NUnit-VisualBasic/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů xUnit",
-    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
+    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET ve Windows, Linuxu a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit-Testprojekt",
-    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Project",
-    "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de pruebas xUnit",
-    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test xUnit",
-    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test xUnit",
-    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit テスト プロジェクト",
-    "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
+    "description": "Windows、Linux、および MacOS 上の .NET で実行できる xUnit.net テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów xUnit",
-    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste do xUnit",
-    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET em Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект xUnit",
-    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "xUnit"],
   "name": "xUnit Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
   "precedence": "8000",
   "identity": "Microsoft.Test.xUnit.CSharp.6.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS’ta .NET üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 测试项目",
-    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
+    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET 上运行"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-CSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 測試專案",
-    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
+    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET 上執行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů xUnit",
-    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
+    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET ve Windows, Linuxu a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit-Testprojekt",
-    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Project",
-    "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de pruebas xUnit",
-    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test xUnit",
-    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test xUnit",
-    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit テスト プロジェクト",
-    "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
+    "description": "Windows、Linux、および MacOS 上の .NET で実行できる xUnit.net テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów xUnit",
-    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste do xUnit",
-    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET em Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект xUnit",
-    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "xUnit"],
   "name": "xUnit Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
   "precedence": "8000",
   "identity": "Microsoft.Test.xUnit.FSharp.6.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS’ta .NET üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 测试项目",
-    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
+    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET 上运行"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-FSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 測試專案",
-    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
+    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET 上執行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů xUnit",
-    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
+    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET ve Windows, Linuxu a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit-Testprojekt",
-    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Project",
-    "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de pruebas xUnit",
-    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test xUnit",
-    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test xUnit",
-    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit テスト プロジェクト",
-    "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
+    "description": "Windows、Linux、および MacOS 上の .NET で実行できる xUnit.net テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów xUnit",
-    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste do xUnit",
-    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET em Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект xUnit",
-    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "xUnit"],
   "name": "xUnit Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
   "precedence": "8000",
   "identity": "Microsoft.Test.xUnit.VisualBasic.6.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS’ta .NET üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 测试项目",
-    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
+    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET 上运行"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.6.0/content/XUnit-VisualBasic/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 測試專案",
-    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
+    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET 上執行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů MSTest",
-    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
+    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET ve Windows, Linuxu a MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest-Testprojekt",
-    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
+    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET unter Windows, Linux und MacOS ausgeführt werden."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Project",
-    "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba de MSTest",
-    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test MSTest ",
-    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test MSTest",
-    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest テスト プロジェクト",
-    "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
+    "description": "Windows、Linux、MacOS 上の .NET で実行できる MSTest 単体テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów MSTest",
-    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste MSTest",
-    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET no Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Проект тестов MSTest",
-    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "MSTest"],
   "name": "MSTest Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",
   "precedence": "9000",
   "identity": "Microsoft.Test.MSTest.CSharp.7.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Projesi",
-    "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS'ta .NET üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 测试项目",
-    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
+    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-CSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 測試專案",
-    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
+    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET 上執行的 MSTest 單元測試。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů MSTest",
-    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
+    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET ve Windows, Linuxu a MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest-Testprojekt",
-    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
+    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET unter Windows, Linux und MacOS ausgeführt werden."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Project",
-    "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba de MSTest",
-    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test MSTest ",
-    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test MSTest",
-    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest テスト プロジェクト",
-    "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
+    "description": "Windows、Linux、MacOS 上の .NET で実行できる MSTest 単体テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów MSTest",
-    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste MSTest",
-    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET no Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Проект тестов MSTest",
-    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "MSTest"],
   "name": "MSTest Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",
   "precedence": "9000",
   "identity": "Microsoft.Test.MSTest.FSharp.7.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Projesi",
-    "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS'ta .NET üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 测试项目",
-    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
+    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-FSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 測試專案",
-    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
+    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET 上執行的 MSTest 單元測試。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů MSTest",
-    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
+    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET ve Windows, Linuxu a MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest-Testprojekt",
-    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
+    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET unter Windows, Linux und MacOS ausgeführt werden."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Project",
-    "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba de MSTest",
-    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test MSTest ",
-    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test MSTest",
-    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest テスト プロジェクト",
-    "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
+    "description": "Windows、Linux、MacOS 上の .NET で実行できる MSTest 単体テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów MSTest",
-    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste MSTest",
-    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET no Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Проект тестов MSTest",
-    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "MSTest"],
   "name": "MSTest Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",
   "precedence": "9000",
   "identity": "Microsoft.Test.MSTest.VisualBasic.7.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Projesi",
-    "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS'ta .NET üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 测试项目",
-    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
+    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/MSTest-VisualBasic/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 測試專案",
-    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
+    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET 上執行的 MSTest 單元測試。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp-Item/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/template.json
@@ -5,7 +5,7 @@
   "name": "NUnit 3 Test Project",
   "defaultName": "NUnitTestProject",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
   "precedence": "9000",
   "identity": "NUnit3.DotNetNew.Template.CSharp.7.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-CSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp-Item/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/template.json
@@ -5,7 +5,7 @@
   "name": "NUnit 3 Test Project",
   "defaultName": "NUnitTestProject",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
   "precedence": "9000",
   "identity": "NUnit3.DotNetNew.Template.FSharp.7.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-FSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic-Item/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/template.json
@@ -5,7 +5,7 @@
   "name": "NUnit 3 Test Project",
   "defaultName": "NUnitTestProject",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
   "precedence": "9000",
   "identity": "NUnit3.DotNetNew.Template.VisualBasic.7.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/NUnit-VisualBasic/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů xUnit",
-    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
+    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET ve Windows, Linuxu a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit-Testprojekt",
-    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Project",
-    "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de pruebas xUnit",
-    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test xUnit",
-    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test xUnit",
-    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit テスト プロジェクト",
-    "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
+    "description": "Windows、Linux、および MacOS 上の .NET で実行できる xUnit.net テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów xUnit",
-    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste do xUnit",
-    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET em Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект xUnit",
-    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "xUnit"],
   "name": "xUnit Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
   "precedence": "9000",
   "identity": "Microsoft.Test.xUnit.CSharp.7.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS’ta .NET üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 测试项目",
-    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
+    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET 上运行"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-CSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 測試專案",
-    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
+    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET 上執行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů xUnit",
-    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
+    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET ve Windows, Linuxu a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit-Testprojekt",
-    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Project",
-    "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de pruebas xUnit",
-    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test xUnit",
-    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test xUnit",
-    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit テスト プロジェクト",
-    "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
+    "description": "Windows、Linux、および MacOS 上の .NET で実行できる xUnit.net テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów xUnit",
-    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste do xUnit",
-    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET em Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект xUnit",
-    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "xUnit"],
   "name": "xUnit Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
   "precedence": "9000",
   "identity": "Microsoft.Test.xUnit.FSharp.7.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS’ta .NET üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 测试项目",
-    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
+    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET 上运行"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-FSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 測試專案",
-    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
+    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET 上執行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů xUnit",
-    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
+    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET ve Windows, Linuxu a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit-Testprojekt",
-    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Project",
-    "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de pruebas xUnit",
-    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test xUnit",
-    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test xUnit",
-    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit テスト プロジェクト",
-    "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
+    "description": "Windows、Linux、および MacOS 上の .NET で実行できる xUnit.net テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów xUnit",
-    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste do xUnit",
-    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET em Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект xUnit",
-    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "xUnit"],
   "name": "xUnit Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
   "precedence": "9000",
   "identity": "Microsoft.Test.xUnit.VisualBasic.7.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS’ta .NET üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 测试项目",
-    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
+    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET 上运行"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.7.0/content/XUnit-VisualBasic/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 測試專案",
-    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
+    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET 上執行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/Microsoft.DotNet.Test.ProjectTemplates.7.0.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/Microsoft.DotNet.Test.ProjectTemplates.7.0.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>netstandard1.0</TargetFramework>
+        <IncludeBuildOutput>False</IncludeBuildOutput>
+        <IncludeSource>False</IncludeSource>
+        <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+        <OutputPath>$(TemplatesFolder)</OutputPath>
+        <EnableDefaultItems>False</EnableDefaultItems>
+        <IsPackable>true</IsPackable>
+        <NoPackageAnalysis>true</NoPackageAnalysis>
+        <NoWarn>2008;NU5125</NoWarn>
+
+        <PackageId>Microsoft.DotNet.Test.ProjectTemplates.7.0</PackageId>
+        <Authors>Microsoft</Authors>
+        <Description>Test Templates for Microsoft Template Engine</Description>
+        <language>en-US</language>
+        <PackageProjectUrl>https://github.com/dotnet/test-templates</PackageProjectUrl>
+        <CopyrightMicrosoft>© Microsoft Corporation. All rights reserved.</CopyrightMicrosoft>
+        <CopyrightNetFoundation>© .NET Foundation and Contributors</CopyrightNetFoundation>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageType>Template</PackageType>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Remove="Microsoft.NETCore.App" />
+        <Compile Remove="$(GitInfoFile)" />
+        <Compile Remove="$(MSBuildThisFileDirectory)../../src/GitInfo.cs" />
+        <Content Include="content\**">
+            <PackagePath>content</PackagePath>
+        </Content>
+    </ItemGroup>
+</Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/Microsoft.DotNet.Test.ProjectTemplates.8.0.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/Microsoft.DotNet.Test.ProjectTemplates.8.0.csproj
@@ -10,7 +10,7 @@
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <NoWarn>2008;NU5125</NoWarn>
 
-        <PackageId>Microsoft.DotNet.Test.ProjectTemplates.7.0</PackageId>
+        <PackageId>Microsoft.DotNet.Test.ProjectTemplates.8.0</PackageId>
         <Authors>Microsoft</Authors>
         <Description>Test Templates for Microsoft Template Engine</Description>
         <language>en-US</language>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů MSTest",
-    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
+    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET ve Windows, Linuxu a MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/cs-CZ/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testů MSTest",
+    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/de-DE/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest-Testprojekt",
+    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest-Testprojekt",
-    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
+    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET unter Windows, Linux und MacOS ausgeführt werden."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/dotnetcli.host.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "TargetFrameworkOverride": {
+      "isHidden": "true",
+      "longName": "target-framework-override",
+      "shortName": ""
+    },
+    "Framework": {
+      "longName": "framework"
+    },
+    "EnablePack": {
+      "shortName": "p",
+      "longName": "enable-pack"
+    },
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  },
+  "usageExamples": [
+    ""
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Project",
-    "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/en-US/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest Test Project",
+    "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/es-ES/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Proyecto de prueba de MSTest",
+    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba de MSTest",
-    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test MSTest ",
-    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/fr-FR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projet de test MSTest ",
+    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test MSTest",
-    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/it-IT/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Progetto di test MSTest",
+    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest テスト プロジェクト",
-    "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
+    "description": "Windows、Linux、MacOS 上の .NET で実行できる MSTest 単体テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/ja-JP/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest テスト プロジェクト",
+    "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/ko-KR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest 테스트 프로젝트",
+    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/pl-PL/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testów MSTest",
+    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów MSTest",
-    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/pt-BR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projeto de Teste MSTest",
+    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste MSTest",
-    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET no Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Проект тестов MSTest",
-    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/ru-RU/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Проект тестов MSTest",
+    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/template.json
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net8.0",
-          "description": "Target net8.0"
+          "choice": "net7.0",
+          "description": "Target net7.0"
         }
       ],
-      "replaces": "net8.0",
-      "defaultValue": "net8.0"
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "MSTest"],
   "name": "MSTest Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",
   "precedence": "10000",
   "identity": "Microsoft.Test.MSTest.CSharp.7.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/template.json
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net7.0",
-          "description": "Target net7.0"
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
-      "replaces": "net7.0",
-      "defaultValue": "net7.0"
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/template.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": ["Test", "MSTest"],
+  "name": "MSTest Test Project",
+  "generatorVersions": "[1.0.0.0-*)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "groupIdentity": "Microsoft.Test.MSTest",
+  "precedence": "9000",
+  "identity": "Microsoft.Test.MSTest.CSharp.7.0",
+  "shortName": "mstest",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "Company.TestProject1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": ""
+    },
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net7.0",
+          "description": "Target net7.0"
+        }
+      ],
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
+    },
+    "EnablePack": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project."
+    },
+    "HostIdentifier": {
+      "type": "bind",
+      "binding": "HostIdentifier"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
+    }
+  },
+  "primaryOutputs": [
+    { "path": "Company.TestProject1.csproj" },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "UnitTest1.cs"
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "Usings.cs"
+    }
+  ],
+  "defaultName": "TestProject1",
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
+      "continueOnError": true
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens Class1.cs in the editor",
+      "manualInstructions": [],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
+      "args": {
+        "files": "1"
+      },
+      "continueOnError": true
+    }
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",
-  "precedence": "9000",
+  "precedence": "10000",
   "identity": "Microsoft.Test.MSTest.CSharp.7.0",
   "shortName": "mstest",
   "tags": {
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net7.0",
-          "description": "Target net7.0"
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
-      "replaces": "net7.0",
-      "defaultValue": "net7.0"
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/template.json
@@ -44,7 +44,7 @@
     },
     "HostIdentifier": {
       "type": "bind",
-      "binding": "HostIdentifier"
+      "binding": "host:HostIdentifier"
     },
     "skipRestore": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/tr-TR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest Test Projesi",
+    "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Projesi",
-    "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS'ta .NET üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/zh-CN/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest 测试项目",
+    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 测试项目",
-    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
+    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 測試專案",
-    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
+    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET 上執行的 MSTest 單元測試。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/.template.config/zh-TW/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest 測試專案",
+    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+</Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/UnitTest1.cs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/UnitTest1.cs
@@ -1,0 +1,10 @@
+namespace Company.TestProject1;
+
+[TestClass]
+public class UnitTest1
+{
+    [TestMethod]
+    public void TestMethod1()
+    {
+    }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/Usings.cs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/Usings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů MSTest",
-    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
+    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET ve Windows, Linuxu a MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/cs-CZ/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testů MSTest",
+    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/de-DE/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest-Testprojekt",
+    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest-Testprojekt",
-    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
+    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET unter Windows, Linux und MacOS ausgeführt werden."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/dotnetcli.host.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "TargetFrameworkOverride": {
+      "isHidden": "true",
+      "longName": "target-framework-override",
+      "shortName": ""
+    },
+    "Framework": {
+      "longName": "framework"
+    },
+    "EnablePack": {
+      "shortName": "p",
+      "longName": "enable-pack"
+    },
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  },
+  "usageExamples": [
+    ""
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Project",
-    "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/en-US/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest Test Project",
+    "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/es-ES/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Proyecto de prueba de MSTest",
+    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba de MSTest",
-    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test MSTest ",
-    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/fr-FR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projet de test MSTest ",
+    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test MSTest",
-    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/it-IT/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Progetto di test MSTest",
+    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest テスト プロジェクト",
-    "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
+    "description": "Windows、Linux、MacOS 上の .NET で実行できる MSTest 単体テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/ja-JP/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest テスト プロジェクト",
+    "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/ko-KR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest 테스트 프로젝트",
+    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/pl-PL/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testów MSTest",
+    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów MSTest",
-    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/pt-BR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projeto de Teste MSTest",
+    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste MSTest",
-    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET no Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Проект тестов MSTest",
-    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/ru-RU/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Проект тестов MSTest",
+    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/template.json
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net8.0",
-          "description": "Target net8.0"
+          "choice": "net7.0",
+          "description": "Target net7.0"
         }
       ],
-      "replaces": "net8.0",
-      "defaultValue": "net8.0"
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/template.json
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net7.0",
-          "description": "Target net7.0"
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
-      "replaces": "net7.0",
-      "defaultValue": "net7.0"
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "MSTest"],
   "name": "MSTest Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",
   "precedence": "10000",
   "identity": "Microsoft.Test.MSTest.FSharp.7.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/template.json
@@ -44,7 +44,7 @@
     },
     "HostIdentifier": {
       "type": "bind",
-      "binding": "HostIdentifier"
+      "binding": "host:HostIdentifier"
     },
     "skipRestore": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/template.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": ["Test", "MSTest"],
+  "name": "MSTest Test Project",
+  "generatorVersions": "[1.0.0.0-*)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "groupIdentity": "Microsoft.Test.MSTest",
+  "precedence": "9000",
+  "identity": "Microsoft.Test.MSTest.FSharp.7.0",
+  "shortName": "mstest",
+  "tags": {
+    "language": "F#",
+    "type": "project"
+  },
+  "sourceName": "Company.TestProject1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": ""
+    },
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net7.0",
+          "description": "Target net7.0"
+        }
+      ],
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
+    },
+    "EnablePack": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project."
+    },
+    "HostIdentifier": {
+      "type": "bind",
+      "binding": "HostIdentifier"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
+    }
+  },
+  "primaryOutputs": [
+    { "path": "Company.TestProject1.fsproj" },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "Tests.fs"
+    }
+  ],
+  "defaultName": "TestProject1",
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
+      "continueOnError": true
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens Tests.fs in the editor",
+      "manualInstructions": [],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
+      "args": {
+        "files": "1"
+      },
+      "continueOnError": true
+    }
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",
-  "precedence": "9000",
+  "precedence": "10000",
   "identity": "Microsoft.Test.MSTest.FSharp.7.0",
   "shortName": "mstest",
   "tags": {
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net7.0",
-          "description": "Target net7.0"
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
-      "replaces": "net7.0",
-      "defaultValue": "net7.0"
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/tr-TR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest Test Projesi",
+    "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Projesi",
-    "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS'ta .NET üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/zh-CN/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest 测试项目",
+    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 测试项目",
-    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
+    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 測試專案",
-    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
+    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET 上執行的 MSTest 單元測試。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/zh-TW/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest 測試專案",
+    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
 

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
 

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
+
+    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
+    <GenerateProgramFile>false</GenerateProgramFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Tests.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+</Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/Program.fs
@@ -1,0 +1,1 @@
+module Program = let [<EntryPoint>] main _ = 0

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/Tests.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/Tests.fs
@@ -1,0 +1,11 @@
+namespace Company.TestProject1
+
+open System
+open Microsoft.VisualStudio.TestTools.UnitTesting
+
+[<TestClass>]
+type TestClass () =
+
+    [<TestMethod>]
+    member this.TestMethodPassing () =
+        Assert.IsTrue(true);

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů MSTest",
-    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
+    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET ve Windows, Linuxu a MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/cs-CZ/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testů MSTest",
+    "description": "Projekt obsahující testy jednotek MSTest, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/de-DE/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest-Testprojekt",
+    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest-Testprojekt",
-    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET Core unter Windows, Linux und MacOS ausgeführt werden."
+    "description": "Ein Projekt, das MSTest-Komponententests enthält, kann in .NET unter Windows, Linux und MacOS ausgeführt werden."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/dotnetcli.host.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "TargetFrameworkOverride": {
+      "isHidden": "true",
+      "longName": "target-framework-override",
+      "shortName": ""
+    },
+    "Framework": {
+      "longName": "framework"
+    },
+    "EnablePack": {
+      "shortName": "p",
+      "longName": "enable-pack"
+    },
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  },
+  "usageExamples": [
+    ""
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Project",
-    "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/en-US/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest Test Project",
+    "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/es-ES/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Proyecto de prueba de MSTest",
+    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba de MSTest",
-    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas unitarias de MSTest que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test MSTest ",
-    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/fr-FR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projet de test MSTest ",
+    "description": "Projet qui contient des tests unitaires MSTest pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test MSTest",
-    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/it-IT/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Progetto di test MSTest",
+    "description": "Progetto che contiene gli unit test MSTest eseguibili in .NET Core in Windows, Linux e MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest テスト プロジェクト",
-    "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
+    "description": "Windows、Linux、MacOS 上の .NET で実行できる MSTest 単体テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/ja-JP/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest テスト プロジェクト",
+    "description": "Windows、Linux、MacOS 上の .NET Core で実行できる MSTest 単体テストを含むプロジェクト。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/ko-KR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest 테스트 프로젝트",
+    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 MSTest 단위 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/pl-PL/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testów MSTest",
+    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów MSTest",
-    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy jednostkowe MSTest, które można uruchomić w środowisku .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/pt-BR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projeto de Teste MSTest",
+    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste MSTest",
-    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET Core no Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes de unidade MSTest que podem ser executados no .NET no Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Проект тестов MSTest",
-    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/ru-RU/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Проект тестов MSTest",
+    "description": "Проект, содержащий модульные тесты MSTest, которые можно выполнять на платформе .NET Core в Windows, Linux и MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net8.0",
-          "description": "Target net8.0"
+          "choice": "net7.0",
+          "description": "Target net7.0"
         }
       ],
-      "replaces": "net8.0",
-      "defaultValue": "net8.0"
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net7.0",
-          "description": "Target net7.0"
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
-      "replaces": "net7.0",
-      "defaultValue": "net7.0"
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "MSTest"],
   "name": "MSTest Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "description": "A project that contains MSTest unit tests that can run on .NET on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",
   "precedence": "10000",
   "identity": "Microsoft.Test.MSTest.VisualBasic.7.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
   "groupIdentity": "Microsoft.Test.MSTest",
-  "precedence": "9000",
+  "precedence": "10000",
   "identity": "Microsoft.Test.MSTest.VisualBasic.7.0",
   "shortName": "mstest",
   "tags": {
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net7.0",
-          "description": "Target net7.0"
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
-      "replaces": "net7.0",
-      "defaultValue": "net7.0"
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -44,7 +44,7 @@
     },
     "HostIdentifier": {
       "type": "bind",
-      "binding": "HostIdentifier"
+      "binding": "host:HostIdentifier"
     },
     "skipRestore": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": ["Test", "MSTest"],
+  "name": "MSTest Test Project",
+  "generatorVersions": "[1.0.0.0-*)",
+  "description": "A project that contains MSTest unit tests that can run on .NET Core on Windows, Linux and MacOS.",
+  "groupIdentity": "Microsoft.Test.MSTest",
+  "precedence": "9000",
+  "identity": "Microsoft.Test.MSTest.VisualBasic.7.0",
+  "shortName": "mstest",
+  "tags": {
+    "language": "VB",
+    "type": "project"
+  },
+  "sourceName": "Company.TestProject1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": ""
+    },
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net7.0",
+          "description": "Target net7.0"
+        }
+      ],
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
+    },
+    "EnablePack": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project."
+    },
+    "HostIdentifier": {
+      "type": "bind",
+      "binding": "HostIdentifier"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
+    }
+  },
+  "primaryOutputs": [
+    { "path": "Company.TestProject1.vbproj" },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "UnitTest1.vb"
+    }
+  ],
+  "defaultName": "TestProject1",
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
+      "continueOnError": true
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens Class1.cs in the editor",
+      "manualInstructions": [],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
+      "args": {
+        "files": "1"
+      },
+      "continueOnError": true
+    }
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/tr-TR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest Test Projesi",
+    "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest Test Projesi",
-    "description": "Windows, Linux ve MacOS'ta .NET Core üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS'ta .NET üzerinde çalışabilen MSTest birim testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/zh-CN/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest 测试项目",
+    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 测试项目",
-    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行。"
+    "description": "包含 MSTest 单元测试的项目，该单元测试可在 Windows、Linux 和 MacOS 上的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "MSTest 測試專案",
-    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
+    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET 上執行的 MSTest 單元測試。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/.template.config/zh-TW/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "MSTest 測試專案",
+    "description": "專案含有可在 Windows、Linux 及 MacOS 的 .NET Core 上執行的 MSTest 單元測試。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>Company.TestProject1</RootNamespace>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
 
     <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>Company.TestProject1</RootNamespace>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+
+    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+</Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>Company.TestProject1</RootNamespace>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
 
     <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/UnitTest1.vb
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/UnitTest1.vb
@@ -1,0 +1,12 @@
+Imports Microsoft.VisualStudio.TestTools.UnitTesting
+
+Namespace Company.TestProject1
+    <TestClass>
+    Public Class UnitTest1
+        <TestMethod>
+        Sub TestSub()
+
+        End Sub
+    End Class
+End Namespace
+

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/cs-CZ/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testu NUnit",
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/de-DE/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit-Testprojekt",
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/en-US/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit Test Project",
+    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/es-ES/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Proyecto de prueba NUnit",
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/fr-FR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projet de test NUnit",
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/it-IT/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Progetto di Test NUnit",
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/ja-JP/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit テスト プロジェクト",
+    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/ko-KR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit 테스트 프로젝트",
+    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/pl-PL/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testowy NUnit",
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/pt-BR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projeto de teste NUnit",
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/ru-RU/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Тестовый проект NUnit",
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/template.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "classifications": [ "Test", "NUnit" ],
+  "name": "NUnit 3 Test Item",
+  "defaultName": "NUnitTestItem",
+  "generatorVersions": "[1.0.0.0-*)",
+  "description": "A item that contains NUnit tests",
+  "groupIdentity": "NUnit3.DotNetNew.ItemTemplate",
+  "identity": "NUnit3.DotNetNew.ItemTemplate.CSharp",
+  "shortName": "nunit-test",
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  },
+  "sourceName": "UnitTest1",
+  "preferNameDirectory": true,
+  "primaryOutputs": [
+    { "path": "UnitTest1.cs" }
+  ],
+  "postActions": [
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens created test fixture class in the editor",
+      "manualInstructions": [ ],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
+      "args": {
+        "files": "0"
+      },
+      "continueOnError": true
+    }
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/tr-TR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit Test Projesi",
+    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/zh-CN/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit 测试项目",
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/.template.config/zh-TW/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit 測試專案",
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/UnitTest1.cs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp-Item/UnitTest1.cs
@@ -1,0 +1,18 @@
+using NUnit.Framework;
+
+namespace Tests
+{
+    public class UnitTest1
+    {
+        [SetUp]
+        public void Setup()
+        {
+        }
+
+        [Test]
+        public void Test1()
+        {
+            Assert.Pass();
+        }
+    }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/cs-CZ/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testu NUnit",
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/de-DE/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit-Testprojekt",
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/dotnetcli.host.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "TargetFrameworkOverride": {
+      "isHidden": "true",
+      "longName": "target-framework-override",
+      "shortName": ""
+    },
+    "Framework": {
+      "longName": "framework"
+    },
+    "EnablePack": {
+      "shortName": "p",
+      "longName": "enable-pack"
+    },
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  },
+  "usageExamples": [
+    ""
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/en-US/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit Test Project",
+    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/es-ES/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Proyecto de prueba NUnit",
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/fr-FR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projet de test NUnit",
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/it-IT/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Progetto di Test NUnit",
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/ja-JP/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit テスト プロジェクト",
+    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/ko-KR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit 테스트 프로젝트",
+    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/pl-PL/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testowy NUnit",
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/pt-BR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projeto de teste NUnit",
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/ru-RU/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Тестовый проект NUnit",
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/template.json
@@ -30,12 +30,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net8.0",
-          "description": "Target net8.0"
+          "choice": "net7.0",
+          "description": "Target net7.0"
         }
       ],
-      "replaces": "net8.0",
-      "defaultValue": "net8.0"
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/template.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "classifications": [ "Test", "NUnit" ],
+  "name": "NUnit 3 Test Project",
+  "defaultName": "NUnitTestProject",
+  "generatorVersions": "[1.0.0.0-*)",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "groupIdentity": "NUnit3.DotNetNew.Template",
+  "precedence": "9000",
+  "identity": "NUnit3.DotNetNew.Template.CSharp.7.0",
+  "shortName": "nunit",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "Company.TestProject1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": ""
+    },
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net7.0",
+          "description": "Target net7.0"
+        }
+      ],
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
+    },
+    "EnablePack": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project."
+    },
+    "HostIdentifier": {
+      "type": "bind",
+      "binding": "HostIdentifier"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
+    }
+  },
+  "primaryOutputs": [
+    { "path": "Company.TestProject1.csproj" },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "UnitTest1.cs"
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "Usings.cs"
+    }
+  ],
+  "defaultName": "TestProject1",
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
+      "continueOnError": true
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens UnitTest1.cs in the editor",
+      "manualInstructions": [ ],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
+      "args": {
+        "files": "1"
+      },
+      "continueOnError": true
+    }
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/template.json
@@ -30,12 +30,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net7.0",
-          "description": "Target net7.0"
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
-      "replaces": "net7.0",
-      "defaultValue": "net7.0"
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/template.json
@@ -3,7 +3,7 @@
   "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
   "classifications": [ "Test", "NUnit" ],
   "name": "NUnit 3 Test Project",
-  "defaultName": "NUnitTestProject",
+  "defaultName": "TestProject1",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
@@ -45,7 +45,7 @@
     },
     "HostIdentifier": {
       "type": "bind",
-      "binding": "HostIdentifier"
+      "binding": "host:HostIdentifier"
     },
     "skipRestore": {
       "type": "parameter",
@@ -65,7 +65,6 @@
       "path": "Usings.cs"
     }
   ],
-  "defaultName": "TestProject1",
   "postActions": [
     {
       "condition": "(!skipRestore)",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/template.json
@@ -5,7 +5,7 @@
   "name": "NUnit 3 Test Project",
   "defaultName": "TestProject1",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
   "precedence": "10000",
   "identity": "NUnit3.DotNetNew.Template.CSharp.7.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/template.json
@@ -7,7 +7,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
-  "precedence": "9000",
+  "precedence": "10000",
   "identity": "NUnit3.DotNetNew.Template.CSharp.7.0",
   "shortName": "nunit",
   "tags": {
@@ -30,12 +30,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net7.0",
-          "description": "Target net7.0"
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
-      "replaces": "net7.0",
-      "defaultValue": "net7.0"
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/tr-TR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit Test Projesi",
+    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/zh-CN/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit 测试项目",
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/.template.config/zh-TW/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit 測試專案",
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/Company.TestProject1.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+</Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/Company.TestProject1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/Company.TestProject1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/UnitTest1.cs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/UnitTest1.cs
@@ -1,0 +1,15 @@
+namespace Company.TestProject1;
+
+public class Tests
+{
+    [SetUp]
+    public void Setup()
+    {
+    }
+
+    [Test]
+    public void Test1()
+    {
+        Assert.Pass();
+    }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/Usings.cs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-CSharp/Usings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/cs-CZ/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testu NUnit",
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/de-DE/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit-Testprojekt",
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/en-US/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit Test Project",
+    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/es-ES/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Proyecto de prueba NUnit",
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/fr-FR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projet de test NUnit",
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/it-IT/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Progetto di Test NUnit",
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/ja-JP/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit テスト プロジェクト",
+    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/ko-KR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit 테스트 프로젝트",
+    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/pl-PL/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testowy NUnit",
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/pt-BR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projeto de teste NUnit",
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/ru-RU/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Тестовый проект NUnit",
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/template.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "classifications": [ "Test", "NUnit" ],
+  "name": "NUnit 3 Test Item",
+  "defaultName": "NUnitTestItem",
+  "generatorVersions": "[1.0.0.0-*)",
+  "description": "A item that contains NUnit tests",
+  "groupIdentity": "NUnit3.DotNetNew.ItemTemplate",
+  "identity": "NUnit3.DotNetNew.ItemTemplate.FSharp",
+  "shortName": "nunit-test",
+  "tags": {
+    "language": "F#",
+    "type": "item"
+  },
+  "sourceName": "UnitTest1",
+  "preferNameDirectory": true,
+  "primaryOutputs": [
+    { "path": "UnitTest1.fs" }
+  ],
+  "postActions": [
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens created test fixture class in the editor",
+      "manualInstructions": [ ],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
+      "args": {
+        "files": "0"
+      },
+      "continueOnError": true
+    }
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/tr-TR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit Test Projesi",
+    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/zh-CN/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit 测试项目",
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/.template.config/zh-TW/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit 測試專案",
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/UnitTest1.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp-Item/UnitTest1.fs
@@ -1,0 +1,11 @@
+module Tests
+
+open NUnit.Framework
+
+[<SetUp>]
+let Setup () =
+    ()
+
+[<Test>]
+let Test1 () =
+    Assert.Pass()

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/cs-CZ/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testu NUnit",
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/de-DE/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit-Testprojekt",
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/dotnetcli.host.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "TargetFrameworkOverride": {
+      "isHidden": "true",
+      "longName": "target-framework-override",
+      "shortName": ""
+    },
+    "Framework": {
+      "longName": "framework"
+    },
+    "EnablePack": {
+      "shortName": "p",
+      "longName": "enable-pack"
+    },
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  },
+  "usageExamples": [
+    ""
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/en-US/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit Test Project",
+    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/es-ES/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Proyecto de prueba NUnit",
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/fr-FR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projet de test NUnit",
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/it-IT/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Progetto di Test NUnit",
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/ja-JP/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit テスト プロジェクト",
+    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/ko-KR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit 테스트 프로젝트",
+    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/pl-PL/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testowy NUnit",
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/pt-BR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projeto de teste NUnit",
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/ru-RU/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Тестовый проект NUnit",
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/template.json
@@ -30,12 +30,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net8.0",
-          "description": "Target net8.0"
+          "choice": "net7.0",
+          "description": "Target net7.0"
         }
       ],
-      "replaces": "net8.0",
-      "defaultValue": "net8.0"
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/template.json
@@ -7,7 +7,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
-  "precedence": "9000",
+  "precedence": "10000",
   "identity": "NUnit3.DotNetNew.Template.FSharp.7.0",
   "shortName": "nunit",
   "tags": {
@@ -30,12 +30,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net7.0",
-          "description": "Target net7.0"
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
-      "replaces": "net7.0",
-      "defaultValue": "net7.0"
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/template.json
@@ -3,7 +3,7 @@
   "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
   "classifications": [ "Test", "NUnit" ],
   "name": "NUnit 3 Test Project",
-  "defaultName": "NUnitTestProject",
+  "defaultName": "TestProject1",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
@@ -45,7 +45,7 @@
     },
     "HostIdentifier": {
       "type": "bind",
-      "binding": "HostIdentifier"
+      "binding": "host:HostIdentifier"
     },
     "skipRestore": {
       "type": "parameter",
@@ -61,7 +61,6 @@
       "path": "UnitTest1.fs"
     }
   ],
-  "defaultName": "TestProject1",
   "postActions": [
     {
       "condition": "(!skipRestore)",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/template.json
@@ -30,12 +30,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net7.0",
-          "description": "Target net7.0"
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
-      "replaces": "net7.0",
-      "defaultValue": "net7.0"
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/template.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "classifications": [ "Test", "NUnit" ],
+  "name": "NUnit 3 Test Project",
+  "defaultName": "NUnitTestProject",
+  "generatorVersions": "[1.0.0.0-*)",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "groupIdentity": "NUnit3.DotNetNew.Template",
+  "precedence": "9000",
+  "identity": "NUnit3.DotNetNew.Template.FSharp.7.0",
+  "shortName": "nunit",
+  "tags": {
+    "language": "F#",
+    "type": "project"
+  },
+  "sourceName": "Company.TestProject1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": ""
+    },
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net7.0",
+          "description": "Target net7.0"
+        }
+      ],
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
+    },
+    "EnablePack": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project."
+    },
+    "HostIdentifier": {
+      "type": "bind",
+      "binding": "HostIdentifier"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
+    }
+  },
+  "primaryOutputs": [
+    { "path": "Company.TestProject1.fsproj" },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "UnitTest1.fs"
+    }
+  ],
+  "defaultName": "TestProject1",
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
+      "continueOnError": true
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens UnitTest1.fs in the editor",
+      "manualInstructions": [ ],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
+      "args": {
+        "files": "1"
+      },
+      "continueOnError": true
+    }
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/template.json
@@ -5,7 +5,7 @@
   "name": "NUnit 3 Test Project",
   "defaultName": "TestProject1",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
   "precedence": "10000",
   "identity": "NUnit3.DotNetNew.Template.FSharp.7.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/tr-TR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit Test Projesi",
+    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/zh-CN/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit 测试项目",
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/.template.config/zh-TW/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit 測試專案",
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/Company.TestProject1.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
 

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/Company.TestProject1.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
 

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/Company.TestProject1.fsproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
+
+    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
+    <GenerateProgramFile>false</GenerateProgramFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="UnitTest1.fs"/>
+    <Compile Include="Program.fs"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+</Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/Program.fs
@@ -1,0 +1,4 @@
+module Program =
+
+    [<EntryPoint>]
+    let main _ = 0

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/UnitTest1.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/UnitTest1.fs
@@ -1,0 +1,11 @@
+module Company.TestProject1
+
+open NUnit.Framework
+
+[<SetUp>]
+let Setup () =
+    ()
+
+[<Test>]
+let Test1 () =
+    Assert.Pass()

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/cs-CZ/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testu NUnit",
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/de-DE/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit-Testprojekt",
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/en-US/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit Test Project",
+    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/es-ES/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Proyecto de prueba NUnit",
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/fr-FR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projet de test NUnit",
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/it-IT/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Progetto di Test NUnit",
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/ja-JP/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit テスト プロジェクト",
+    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/ko-KR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit 테스트 프로젝트",
+    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/pl-PL/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testowy NUnit",
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/pt-BR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projeto de teste NUnit",
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/ru-RU/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Тестовый проект NUnit",
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/template.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "classifications": [ "Test", "NUnit" ],
+  "name": "NUnit 3 Test Item",
+  "defaultName": "NUnitTestItem",
+  "generatorVersions": "[1.0.0.0-*)",
+  "description": "A item that contains NUnit tests",
+  "groupIdentity": "NUnit3.DotNetNew.ItemTemplate",
+  "identity": "NUnit3.DotNetNew.ItemTemplate.VisualBasic",
+  "shortName": "nunit-test",
+  "tags": {
+    "language": "VB",
+    "type": "item"
+  },
+  "sourceName": "UnitTest1",
+  "preferNameDirectory": true,
+  "primaryOutputs": [
+    { "path": "UnitTest1.vb" }
+  ],
+  "postActions": [
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens created test fixture class in the editor",
+      "manualInstructions": [ ],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
+      "args": {
+        "files": "0"
+      },
+      "continueOnError": true
+    }
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/tr-TR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit Test Projesi",
+    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/zh-CN/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit 测试项目",
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/.template.config/zh-TW/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit 測試專案",
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/UnitTest1.vb
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic-Item/UnitTest1.vb
@@ -1,0 +1,18 @@
+Imports NUnit.Framework
+
+Namespace Tests
+
+    Public Class UnitTest1
+
+        <SetUp>
+        Public Sub Setup()
+        End Sub
+
+        <Test>
+        Public Sub Test1()
+            Assert.Pass()
+        End Sub
+
+    End Class
+
+End Namespace

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/cs-CZ/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testu NUnit",
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testu NUnit",
-    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS"
+    "description": "Projekt obsahující testy NUnit, který se dá spustit na platformě .NET v systémech Windows, Linux a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/de-DE/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit-Testprojekt",
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit-Testprojekt",
-    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das NUnit-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/dotnetcli.host.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "TargetFrameworkOverride": {
+      "isHidden": "true",
+      "longName": "target-framework-override",
+      "shortName": ""
+    },
+    "Framework": {
+      "longName": "framework"
+    },
+    "EnablePack": {
+      "shortName": "p",
+      "longName": "enable-pack"
+    },
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  },
+  "usageExamples": [
+    ""
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/en-US/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit Test Project",
+    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Project",
-    "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de prueba NUnit",
-    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/es-ES/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Proyecto de prueba NUnit",
+    "description": "Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test NUnit",
-    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET sur Windows, Linux et MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/fr-FR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projet de test NUnit",
+    "description": "Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/it-IT/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Progetto di Test NUnit",
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di Test NUnit",
-    "description": "Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test NUnit eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/ja-JP/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit テスト プロジェクト",
+    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit テスト プロジェクト",
-    "description": "Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。"
+    "description": "Windows、Linux および MacOS 上の .NET で実行できる NUnit テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/ko-KR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit 테스트 프로젝트",
+    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testowy NUnit",
-    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/pl-PL/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testowy NUnit",
+    "description": "Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/pt-BR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projeto de teste NUnit",
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de teste NUnit",
-    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS."
+    "description": "Um projeto que contém testes NUnit que podem ser executados no .NET no Windows, no Linux e no MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/ru-RU/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Тестовый проект NUnit",
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект NUnit",
-    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами NUnit, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/template.json
@@ -30,12 +30,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net8.0",
-          "description": "Target net8.0"
+          "choice": "net7.0",
+          "description": "Target net7.0"
         }
       ],
-      "replaces": "net8.0",
-      "defaultValue": "net8.0"
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/template.json
@@ -5,7 +5,7 @@
   "name": "NUnit 3 Test Project",
   "defaultName": "TestProject1",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains NUnit tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
   "precedence": "10000",
   "identity": "NUnit3.DotNetNew.Template.VisualBasic.7.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/template.json
@@ -7,7 +7,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
-  "precedence": "9000",
+  "precedence": "10000",
   "identity": "NUnit3.DotNetNew.Template.VisualBasic.7.0",
   "shortName": "nunit",
   "tags": {
@@ -30,12 +30,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net7.0",
-          "description": "Target net7.0"
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
-      "replaces": "net7.0",
-      "defaultValue": "net7.0"
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/template.json
@@ -30,12 +30,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net7.0",
-          "description": "Target net7.0"
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
-      "replaces": "net7.0",
-      "defaultValue": "net7.0"
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/template.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
+  "classifications": [ "Test", "NUnit" ],
+  "name": "NUnit 3 Test Project",
+  "defaultName": "NUnitTestProject",
+  "generatorVersions": "[1.0.0.0-*)",
+  "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
+  "groupIdentity": "NUnit3.DotNetNew.Template",
+  "precedence": "9000",
+  "identity": "NUnit3.DotNetNew.Template.VisualBasic.7.0",
+  "shortName": "nunit",
+  "tags": {
+    "language": "VB",
+    "type": "project"
+  },
+  "sourceName": "Company.TestProject1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": ""
+    },
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net7.0",
+          "description": "Target net7.0"
+        }
+      ],
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
+    },
+    "EnablePack": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project."
+    },
+    "HostIdentifier": {
+      "type": "bind",
+      "binding": "HostIdentifier"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
+    }
+  },
+  "primaryOutputs": [
+    { "path": "Company.TestProject1.vbproj" },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "UnitTest1.vb"
+    }
+  ],
+  "defaultName": "TestProject1",
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
+      "continueOnError": true
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens UnitTest1.vb in the editor",
+      "manualInstructions": [ ],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
+      "args": {
+        "files": "1"
+      },
+      "continueOnError": true
+    }
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/template.json
@@ -3,7 +3,7 @@
   "author": "Aleksei Kharlov aka halex2005 (codeofclimber.ru)",
   "classifications": [ "Test", "NUnit" ],
   "name": "NUnit 3 Test Project",
-  "defaultName": "NUnitTestProject",
+  "defaultName": "TestProject1",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains NUnit tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "NUnit3.DotNetNew.Template",
@@ -45,7 +45,7 @@
     },
     "HostIdentifier": {
       "type": "bind",
-      "binding": "HostIdentifier"
+      "binding": "host:HostIdentifier"
     },
     "skipRestore": {
       "type": "parameter",
@@ -61,7 +61,6 @@
       "path": "UnitTest1.vb"
     }
   ],
-  "defaultName": "TestProject1",
   "postActions": [
     {
       "condition": "(!skipRestore)",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/tr-TR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit Test Projesi",
+    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje."
+    "description": "Windows, Linux ve MacOS üzerinde .NET'da çalışabilen NUnit testleri içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/zh-CN/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit 测试项目",
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 测试项目",
-    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。"
+    "description": "包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET 上运行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "NUnit 測試專案",
-    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET 執行之 NUnit 測試的專案。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/.template.config/zh-TW/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "NUnit 測試專案",
+    "description": "包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
 

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
+
+    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+</Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
 

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/UnitTest1.vb
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-VisualBasic/UnitTest1.vb
@@ -1,0 +1,18 @@
+Imports NUnit.Framework
+
+Namespace Company.TestProject1
+
+    Public Class Tests
+
+        <SetUp>
+        Public Sub Setup()
+        End Sub
+
+        <Test>
+        Public Sub Test1()
+            Assert.Pass()
+        End Sub
+
+    End Class
+
+End Namespace

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů xUnit",
-    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
+    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET ve Windows, Linuxu a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/cs-CZ/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testů xUnit",
+    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/de-DE/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit-Testprojekt",
+    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit-Testprojekt",
-    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/dotnetcli.host.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "TargetFrameworkOverride": {
+      "isHidden": "true",
+      "longName": "target-framework-override",
+      "shortName": ""
+    },
+    "Framework": {
+      "longName": "framework"
+    },
+    "EnablePack": {
+      "shortName": "p",
+      "longName": "enable-pack"
+    },
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  },
+  "usageExamples": [
+    ""
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/en-US/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit Test Project",
+    "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Project",
-    "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de pruebas xUnit",
-    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/es-ES/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Proyecto de pruebas xUnit",
+    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/fr-FR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projet de test xUnit",
+    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test xUnit",
-    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test xUnit",
-    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/it-IT/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Progetto di test xUnit",
+    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit テスト プロジェクト",
-    "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
+    "description": "Windows、Linux、および MacOS 上の .NET で実行できる xUnit.net テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/ja-JP/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit テスト プロジェクト",
+    "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/ko-KR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit 테스트 프로젝트",
+    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów xUnit",
-    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/pl-PL/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testów xUnit",
+    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/pt-BR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projeto de Teste do xUnit",
+    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste do xUnit",
-    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET em Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект xUnit",
-    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/ru-RU/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Тестовый проект xUnit",
+    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "xUnit"],
   "name": "xUnit Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
   "precedence": "10000",
   "identity": "Microsoft.Test.xUnit.CSharp.7.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/template.json
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net8.0",
-          "description": "Target net8.0"
+          "choice": "net7.0",
+          "description": "Target net7.0"
         }
       ],
-      "replaces": "net8.0",
-      "defaultValue": "net8.0"
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/template.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": ["Test", "xUnit"],
+  "name": "xUnit Test Project",
+  "generatorVersions": "[1.0.0.0-*)",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "groupIdentity": "Microsoft.Test.xUnit",
+  "precedence": "9000",
+  "identity": "Microsoft.Test.xUnit.CSharp.7.0",
+  "shortName": "xunit",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "Company.TestProject1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": ""
+    },
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net7.0",
+          "description": "Target net7.0"
+        }
+      ],
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
+    },
+    "EnablePack": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project."
+    },
+    "HostIdentifier": {
+      "type": "bind",
+      "binding": "HostIdentifier"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
+    }
+  },
+  "primaryOutputs": [
+    { "path": "Company.TestProject1.csproj" },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "UnitTest1.cs"
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "Usings.cs"
+    }
+  ],
+  "defaultName": "TestProject1",
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
+      "continueOnError": true
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens Class1.cs in the editor",
+      "manualInstructions": [],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
+      "args": {
+        "files": "1"
+      },
+      "continueOnError": true
+    }
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/template.json
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net7.0",
-          "description": "Target net7.0"
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
-      "replaces": "net7.0",
-      "defaultValue": "net7.0"
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
-  "precedence": "9000",
+  "precedence": "10000",
   "identity": "Microsoft.Test.xUnit.CSharp.7.0",
   "shortName": "xunit",
   "tags": {
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net7.0",
-          "description": "Target net7.0"
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
-      "replaces": "net7.0",
-      "defaultValue": "net7.0"
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/template.json
@@ -44,7 +44,7 @@
     },
     "HostIdentifier": {
       "type": "bind",
-      "binding": "HostIdentifier"
+      "binding": "host:HostIdentifier"
     },
     "skipRestore": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/tr-TR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit Test Projesi",
+    "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS’ta .NET üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/zh-CN/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit 测试项目",
+    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 测试项目",
-    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
+    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET 上运行"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 測試專案",
-    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
+    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET 上執行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/.template.config/zh-TW/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit 測試專案",
+    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/Company.TestProject1.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/Company.TestProject1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/Company.TestProject1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/UnitTest1.cs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/UnitTest1.cs
@@ -1,0 +1,10 @@
+namespace Company.TestProject1;
+
+public class UnitTest1
+{
+    [Fact]
+    public void Test1()
+    {
+
+    }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/Usings.cs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-CSharp/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů xUnit",
-    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
+    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET ve Windows, Linuxu a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/cs-CZ/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testů xUnit",
+    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/de-DE/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit-Testprojekt",
+    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit-Testprojekt",
-    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/dotnetcli.host.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "TargetFrameworkOverride": {
+      "isHidden": "true",
+      "longName": "target-framework-override",
+      "shortName": ""
+    },
+    "Framework": {
+      "longName": "framework"
+    },
+    "EnablePack": {
+      "shortName": "p",
+      "longName": "enable-pack"
+    },
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  },
+  "usageExamples": [
+    ""
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/en-US/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit Test Project",
+    "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Project",
-    "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de pruebas xUnit",
-    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/es-ES/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Proyecto de pruebas xUnit",
+    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/fr-FR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projet de test xUnit",
+    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test xUnit",
-    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test xUnit",
-    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/it-IT/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Progetto di test xUnit",
+    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit テスト プロジェクト",
-    "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
+    "description": "Windows、Linux、および MacOS 上の .NET で実行できる xUnit.net テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/ja-JP/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit テスト プロジェクト",
+    "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/ko-KR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit 테스트 프로젝트",
+    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów xUnit",
-    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/pl-PL/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testów xUnit",
+    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/pt-BR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projeto de Teste do xUnit",
+    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste do xUnit",
-    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET em Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект xUnit",
-    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/ru-RU/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Тестовый проект xUnit",
+    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/template.json
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net8.0",
-          "description": "Target net8.0"
+          "choice": "net7.0",
+          "description": "Target net7.0"
         }
       ],
-      "replaces": "net8.0",
-      "defaultValue": "net8.0"
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/template.json
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net7.0",
-          "description": "Target net7.0"
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
-      "replaces": "net7.0",
-      "defaultValue": "net7.0"
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/template.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": ["Test", "xUnit"],
+  "name": "xUnit Test Project",
+  "generatorVersions": "[1.0.0.0-*)",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "groupIdentity": "Microsoft.Test.xUnit",
+  "precedence": "9000",
+  "identity": "Microsoft.Test.xUnit.FSharp.7.0",
+  "shortName": "xunit",
+  "tags": {
+    "language": "F#",
+    "type": "project"
+  },
+  "sourceName": "Company.TestProject1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": ""
+    },
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net7.0",
+          "description": "Target net7.0"
+        }
+      ],
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
+    },
+    "EnablePack": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project."
+    },
+    "HostIdentifier": {
+      "type": "bind",
+      "binding": "HostIdentifier"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
+    }
+  },
+  "primaryOutputs": [
+    { "path": "Company.TestProject1.fsproj" },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "Tests.fs"
+    }
+  ],
+  "defaultName": "TestProject1",
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
+      "continueOnError": true
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens Tests.fs in the editor",
+      "manualInstructions": [],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
+      "args": {
+        "files": "1"
+      },
+      "continueOnError": true
+    }
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "xUnit"],
   "name": "xUnit Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
   "precedence": "10000",
   "identity": "Microsoft.Test.xUnit.FSharp.7.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
-  "precedence": "9000",
+  "precedence": "10000",
   "identity": "Microsoft.Test.xUnit.FSharp.7.0",
   "shortName": "xunit",
   "tags": {
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net7.0",
-          "description": "Target net7.0"
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
-      "replaces": "net7.0",
-      "defaultValue": "net7.0"
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/template.json
@@ -44,7 +44,7 @@
     },
     "HostIdentifier": {
       "type": "bind",
-      "binding": "HostIdentifier"
+      "binding": "host:HostIdentifier"
     },
     "skipRestore": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/tr-TR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit Test Projesi",
+    "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS’ta .NET üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/zh-CN/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit 测试项目",
+    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 测试项目",
-    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
+    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET 上运行"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 測試專案",
-    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
+    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET 上執行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/.template.config/zh-TW/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit 測試專案",
+    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/Company.TestProject1.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
 

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/Company.TestProject1.fsproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
+
+    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
+    <GenerateProgramFile>false</GenerateProgramFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Tests.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/Company.TestProject1.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
 

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/Program.fs
@@ -1,0 +1,1 @@
+module Program = let [<EntryPoint>] main _ = 0

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/Tests.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/Tests.fs
@@ -1,0 +1,8 @@
+module Tests
+
+open System
+open Xunit
+
+[<Fact>]
+let ``My test`` () =
+    Assert.True(true)

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/cs-CZ/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testů xUnit",
-    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
+    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET ve Windows, Linuxu a MacOS"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/cs-CZ/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/cs-CZ/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testů xUnit",
+    "description": "Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/de-DE/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit-Testprojekt",
+    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/de-DE/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/de-DE/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit-Testprojekt",
-    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können."
+    "description": "Ein Projekt, das xUnit.net-Tests enthält, die auf .NET unter Windows, Linux und MacOS ausgeführt werden können."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/dotnetcli.host.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "TargetFrameworkOverride": {
+      "isHidden": "true",
+      "longName": "target-framework-override",
+      "shortName": ""
+    },
+    "Framework": {
+      "longName": "framework"
+    },
+    "EnablePack": {
+      "shortName": "p",
+      "longName": "enable-pack"
+    },
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  },
+  "usageExamples": [
+    ""
+  ]
+}
+

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/en-US/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit Test Project",
+    "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/en-US/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/en-US/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Project",
-    "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS."
+    "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/es-ES/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Proyecto de pruebas xUnit",
-    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET en Windows, Linux y MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/es-ES/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/es-ES/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Proyecto de pruebas xUnit",
+    "description": "Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/fr-FR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projet de test xUnit",
+    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/fr-FR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/fr-FR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projet de test xUnit",
-    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS."
+    "description": "Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET sur Windows, Linux et macOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/it-IT/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Progetto di test xUnit",
-    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
+    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET in Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/it-IT/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/it-IT/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Progetto di test xUnit",
+    "description": "Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/ja-JP/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit テスト プロジェクト",
-    "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
+    "description": "Windows、Linux、および MacOS 上の .NET で実行できる xUnit.net テストを含むプロジェクト。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/ja-JP/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/ja-JP/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit テスト プロジェクト",
+    "description": "Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/ko-KR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit 테스트 프로젝트",
+    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/ko-KR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/ko-KR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 테스트 프로젝트",
-    "description": "Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
+    "description": "Windows, Linux 및 MacOS의 .NET에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/pl-PL/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projekt testów xUnit",
-    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
+    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET w systemach Windows, Linux i MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/pl-PL/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/pl-PL/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projekt testów xUnit",
+    "description": "Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/pt-BR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Projeto de Teste do xUnit",
+    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/pt-BR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/pt-BR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Projeto de Teste do xUnit",
-    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS."
+    "description": "Um projeto que contém testes xUnit.net que podem ser executados no .NET em Windows, Linux e MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/ru-RU/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Тестовый проект xUnit",
-    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET в Windows, Linux и MacOS."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/ru-RU/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/ru-RU/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "Тестовый проект xUnit",
+    "description": "Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/template.json
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net8.0",
-          "description": "Target net8.0"
+          "choice": "net7.0",
+          "description": "Target net7.0"
         }
       ],
-      "replaces": "net8.0",
-      "defaultValue": "net8.0"
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/template.json
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net7.0",
-          "description": "Target net7.0"
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
-      "replaces": "net7.0",
-      "defaultValue": "net7.0"
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/template.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": ["Test", "xUnit"],
+  "name": "xUnit Test Project",
+  "generatorVersions": "[1.0.0.0-*)",
+  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "groupIdentity": "Microsoft.Test.xUnit",
+  "precedence": "9000",
+  "identity": "Microsoft.Test.xUnit.VisualBasic.7.0",
+  "shortName": "xunit",
+  "tags": {
+    "language": "VB",
+    "type": "project"
+  },
+  "sourceName": "Company.TestProject1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": ""
+    },
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net7.0",
+          "description": "Target net7.0"
+        }
+      ],
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
+    },
+    "EnablePack": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project."
+    },
+    "HostIdentifier": {
+      "type": "bind",
+      "binding": "HostIdentifier"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
+    }
+  },
+  "primaryOutputs": [
+    { "path": "Company.TestProject1.vbproj" },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "UnitTest1.vb"
+    }
+  ],
+  "defaultName": "TestProject1",
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
+      "continueOnError": true
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens Class1.cs in the editor",
+      "manualInstructions": [],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "id": "openInEditor",
+      "args": {
+        "files": "1"
+      },
+      "continueOnError": true
+    }
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": ["Test", "xUnit"],
   "name": "xUnit Test Project",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project that contains xUnit.net tests that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
   "precedence": "10000",
   "identity": "Microsoft.Test.xUnit.VisualBasic.7.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/template.json
@@ -44,7 +44,7 @@
     },
     "HostIdentifier": {
       "type": "bind",
-      "binding": "HostIdentifier"
+      "binding": "host:HostIdentifier"
     },
     "skipRestore": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Test.xUnit",
-  "precedence": "9000",
+  "precedence": "10000",
   "identity": "Microsoft.Test.xUnit.VisualBasic.7.0",
   "shortName": "xunit",
   "tags": {
@@ -29,12 +29,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net7.0",
-          "description": "Target net7.0"
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
-      "replaces": "net7.0",
-      "defaultValue": "net7.0"
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/tr-TR/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit Test Projesi",
+    "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/tr-TR/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/tr-TR/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit Test Projesi",
-    "description": "Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
+    "description": "Windows, Linux ve MacOS’ta .NET üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje."
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/zh-CN/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit 测试项目",
+    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/zh-CN/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/zh-CN/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 测试项目",
-    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行"
+    "description": "包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET 上运行"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/zh-TW/strings.json
@@ -2,6 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "xUnit 測試專案",
-    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
+    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET 上執行。"
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/zh-TW/strings.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/.template.config/zh-TW/strings.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0.0",
+  "strings": {
+    "name": "xUnit 測試專案",
+    "description": "此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。"
+  }
+}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/Company.TestProject1.vbproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>Company.TestProject1</RootNamespace>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+
+    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/Company.TestProject1.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>Company.TestProject1</RootNamespace>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
 
     <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/Company.TestProject1.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>Company.TestProject1</RootNamespace>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net7.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
 
     <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/UnitTest1.vb
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-VisualBasic/UnitTest1.vb
@@ -1,0 +1,12 @@
+Imports System
+Imports Xunit
+
+Namespace Company.TestProject1
+    Public Class UnitTest1
+        <Fact>
+        Sub TestSub()
+
+        End Sub
+    End Class
+End Namespace
+

--- a/template_feed/NetCoreTestTemplates.sln
+++ b/template_feed/NetCoreTestTemplates.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Test.Proje
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Test.ProjectTemplates.7.0", "Microsoft.DotNet.Test.ProjectTemplates.7.0\Microsoft.DotNet.Test.ProjectTemplates.7.0.csproj", "{305FAF98-218D-45D6-840E-17BF8FE199AF}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Test.ProjectTemplates.8.0", "Microsoft.DotNet.Test.ProjectTemplates.8.0\Microsoft.DotNet.Test.ProjectTemplates.8.0.csproj", "{15BE3D4B-2E66-47DA-988F-DA12BF37CBBC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{305FAF98-218D-45D6-840E-17BF8FE199AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{305FAF98-218D-45D6-840E-17BF8FE199AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{305FAF98-218D-45D6-840E-17BF8FE199AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{15BE3D4B-2E66-47DA-988F-DA12BF37CBBC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{15BE3D4B-2E66-47DA-988F-DA12BF37CBBC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{15BE3D4B-2E66-47DA-988F-DA12BF37CBBC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{15BE3D4B-2E66-47DA-988F-DA12BF37CBBC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/test/Microsoft.TestTemplates.Acceptance.Tests/AcceptanceTestBase.cs
+++ b/test/Microsoft.TestTemplates.Acceptance.Tests/AcceptanceTestBase.cs
@@ -37,22 +37,22 @@ namespace Microsoft.TestTemplates.Acceptance.Tests
         }
 
         /// <summary>
-        /// Invokes <c>dotnet new -i</c> with specified arguments.
+        /// Invokes <c>dotnet new install</c> with specified arguments.
         /// </summary>
         /// <param name="arguments"></param>
         public static void InvokeDotnetNewInstall(string arguments)
         {
-            var command = "new -i " + arguments;
+            var command = "new install " + arguments;
             ExecuteDotnetNew(command);
         }
 
         /// <summary>
-        /// Invokes <c>dotnet new -i</c> with specified arguments.
+        /// Invokes <c>dotnet new uninstall</c> with specified arguments.
         /// </summary>
         /// <param name="arguments"></param>
         public static void InvokeDotnetNewUninstall(string arguments)
         {
-            var command = "new -u " + arguments;
+            var command = "new uninstall " + arguments;
             ExecuteDotnetNew(command);
         }
 

--- a/test/Microsoft.TestTemplates.Acceptance.Tests/DotNetCoreItemTemplateTests.cs
+++ b/test/Microsoft.TestTemplates.Acceptance.Tests/DotNetCoreItemTemplateTests.cs
@@ -24,7 +24,8 @@ namespace Microsoft.TestTemplates.Acceptance.Tests
              "3.1",
              "5.0",
              "6.0",
-             "7.0"
+             "7.0",
+             "8.0"
         };
 
         /// <summary>

--- a/test/Microsoft.TestTemplates.Acceptance.Tests/DotNetCoreItemTemplateTests.cs
+++ b/test/Microsoft.TestTemplates.Acceptance.Tests/DotNetCoreItemTemplateTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.TestTemplates.Acceptance.Tests
              "5.0",
              "6.0",
              "7.0",
-             "8.0"
+             // "8.0", TODO: not yet, enable when net8.0 sdk can target net8.0
         };
 
         /// <summary>

--- a/test/Microsoft.TestTemplates.Acceptance.Tests/DotnetCoreTemplateTests.cs
+++ b/test/Microsoft.TestTemplates.Acceptance.Tests/DotnetCoreTemplateTests.cs
@@ -20,7 +20,8 @@ namespace Microsoft.TestTemplates.Acceptance.Tests
             "3.1",
             "5.0",
             "6.0",
-            "7.0"
+            "7.0",
+            "8.0"
         };
 
         /// <summary>

--- a/test/Microsoft.TestTemplates.Acceptance.Tests/DotnetCoreTemplateTests.cs
+++ b/test/Microsoft.TestTemplates.Acceptance.Tests/DotnetCoreTemplateTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.TestTemplates.Acceptance.Tests
             "5.0",
             "6.0",
             "7.0",
-            "8.0"
+            // "8.0", TODO: not yet, enable when net8.0 sdk can target net8.0
         };
 
         /// <summary>

--- a/test/Microsoft.TestTemplates.Acceptance.Tests/Microsoft.TestTemplates.Acceptance.Tests.csproj
+++ b/test/Microsoft.TestTemplates.Acceptance.Tests/Microsoft.TestTemplates.Acceptance.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <LangVersion>preview</LangVersion>

--- a/test/Microsoft.TestTemplates.Acceptance.Tests/Microsoft.TestTemplates.Acceptance.Tests.csproj
+++ b/test/Microsoft.TestTemplates.Acceptance.Tests/Microsoft.TestTemplates.Acceptance.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <LangVersion>preview</LangVersion>


### PR DESCRIPTION
Adds package for net8.0 templates. 

But since net8.0 alpha SDK can't target net8.0 yet, all the templates and test projects target net7.0. This will need to be updated later. 