### PR TITLE
Remove outdated properties from azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,9 +49,6 @@ variables:
       /p:VisualStudioDropName=$(_VisualStudioDropName)
       /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
       /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-      /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-      /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-      /p:DotNetPublishToBlobFeed=true
       /p:DotNetPublishUsingPipelines=true
       /p:DotNetArtifactsCategory=.NETCore
       /p:OfficialBuildId=$(BUILD.BUILDNUMBER)


### PR DESCRIPTION
They are no longer used: https://github.com/dotnet/arcade/blob/66c9c5397d599af40f2a94989241944f5a73442a/Documentation/CorePackages/Publishing.md#publishingusingpipelines--deprecated-properties