### PR TITLE
Use MSBuild AssemblyAttribute for MSTest parallelize attribute

### DIFF
--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -24,4 +24,14 @@
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Enable MSTest parallelization at method level -->
+    <AssemblyAttribute Include="Microsoft.VisualStudio.TestTools.UnitTesting.Parallelize">
+      <_Parameter1>Workers = 0</_Parameter1>
+      <_Parameter1_IsLiteral>true</_Parameter1_IsLiteral>
+      <_Parameter2>Scope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.MethodLevel</_Parameter2>
+      <_Parameter2_IsLiteral>true</_Parameter2_IsLiteral>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/.template.config/template.json
@@ -63,6 +63,10 @@
     { "path": "Company.TestProject1.fsproj" },
     {
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "MSTestSettings.fs"
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "path": "Tests.fs"
     }
   ],

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="MSTestSettings.fs" />
     <Compile Include="Tests.fs" />
   </ItemGroup>
 

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/MSTestSettings.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-FSharp/MSTestSettings.fs
@@ -1,0 +1,6 @@
+﻿module MSTestSettings
+
+open Microsoft.VisualStudio.TestTools.UnitTesting
+
+[<assembly: Parallelize(Scope = ExecutionScope.MethodLevel)>]
+do()

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
@@ -18,4 +18,14 @@
     <PackageReference Condition="'$(DisableRunner)' != 'true'" Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.10.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Enable MSTest parallelization at method level -->
+    <AssemblyAttribute Include="Microsoft.VisualStudio.TestTools.UnitTesting.Parallelize">
+      <_Parameter1>Workers:=0</_Parameter1>
+      <_Parameter1_IsLiteral>true</_Parameter1_IsLiteral>
+      <_Parameter2>Scope:=Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.MethodLevel</_Parameter2>
+      <_Parameter2_IsLiteral>true</_Parameter2_IsLiteral>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/.template.config/template.json
@@ -67,10 +67,6 @@
     },
     {
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-      "path": "MSTestSettings.cs"
-    },
-    {
-      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "path": "GlobalUsings.cs"
     }
   ],

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -24,4 +24,14 @@
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Enable MSTest parallelization at method level -->
+    <AssemblyAttribute Include="Microsoft.VisualStudio.TestTools.UnitTesting.Parallelize">
+      <_Parameter1>Workers = 0</_Parameter1>
+      <_Parameter1_IsLiteral>true</_Parameter1_IsLiteral>
+      <_Parameter2>Scope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.MethodLevel</_Parameter2>
+      <_Parameter2_IsLiteral>true</_Parameter2_IsLiteral>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/MSTestSettings.cs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/MSTestSettings.cs
@@ -1,1 +1,0 @@
-﻿[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/.template.config/template.json
@@ -63,6 +63,10 @@
     { "path": "Company.TestProject1.fsproj" },
     {
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "MSTestSettings.fs"
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "path": "Tests.fs"
     }
   ],

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -64,10 +64,6 @@
     {
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "path": "UnitTest1.vb"
-    },
-    {
-      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-      "path": "MSTestSettings.vb"
     }
   ],
   "defaultName": "TestProject1",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
@@ -18,4 +18,14 @@
     <PackageReference Condition="'$(DisableRunner)' != 'true'" Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.10.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Enable MSTest parallelization at method level -->
+    <AssemblyAttribute Include="Microsoft.VisualStudio.TestTools.UnitTesting.Parallelize">
+      <_Parameter1>Workers:=0</_Parameter1>
+      <_Parameter1_IsLiteral>true</_Parameter1_IsLiteral>
+      <_Parameter2>Scope:=Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.MethodLevel</_Parameter2>
+      <_Parameter2_IsLiteral>true</_Parameter2_IsLiteral>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/MSTestSettings.vb
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/MSTestSettings.vb
@@ -1,3 +1,0 @@
-﻿Imports Microsoft.VisualStudio.TestTools.UnitTesting
-
-<Assembly: Parallelize(Scope:=ExecutionScope.MethodLevel)>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/.template.config/template.json
@@ -61,10 +61,6 @@
     },
     {
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-      "path": "MSTestSettings.cs"
-    },
-    {
-      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "path": "GlobalUsings.cs"
     }
   ],

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
@@ -25,4 +25,14 @@
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Enable MSTest parallelization at method level -->
+    <AssemblyAttribute Include="Microsoft.VisualStudio.TestTools.UnitTesting.Parallelize">
+      <_Parameter1>Workers = 0</_Parameter1>
+      <_Parameter1_IsLiteral>true</_Parameter1_IsLiteral>
+      <_Parameter2>Scope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.MethodLevel</_Parameter2>
+      <_Parameter2_IsLiteral>true</_Parameter2_IsLiteral>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/MSTestSettings.cs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/MSTestSettings.cs
@@ -1,1 +1,0 @@
-﻿[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]


### PR DESCRIPTION
Update C# and VB.NET templates to use MSBuild attribute.