### PR TITLE
Fix F# Templates

### DIFF
--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/Program.fs
@@ -1,4 +1,4 @@
-﻿module Program =
+﻿module Program
 
     [<EntryPoint>]
     let main _ = 0

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/NUnit-FSharp/Program.fs
@@ -1,4 +1,4 @@
 ﻿module Program
 
-    [<EntryPoint>]
-    let main _ = 0
+[<EntryPoint>]
+let main _ = 0

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/Program.fs
@@ -1,4 +1,4 @@
 ﻿module Program
 
-    [<EntryPoint>]
-    let main _ = 0
+[<EntryPoint>]
+let main _ = 0

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.8.0/content/XUnit-FSharp/Program.fs
@@ -1,1 +1,4 @@
-﻿module Program = let [<EntryPoint>] main _ = 0
+﻿module Program
+
+    [<EntryPoint>]
+    let main _ = 0

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/NUnit-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/NUnit-FSharp/Program.fs
@@ -1,4 +1,4 @@
-﻿module Program =
+﻿module Program
 
     [<EntryPoint>]
     let main _ = 0

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/NUnit-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/NUnit-FSharp/Program.fs
@@ -1,4 +1,4 @@
 ﻿module Program
 
-    [<EntryPoint>]
-    let main _ = 0
+[<EntryPoint>]
+let main _ = 0

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/XUnit-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/XUnit-FSharp/Program.fs
@@ -1,4 +1,4 @@
 ﻿module Program
 
-    [<EntryPoint>]
-    let main _ = 0
+[<EntryPoint>]
+let main _ = 0

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/XUnit-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/XUnit-FSharp/Program.fs
@@ -1,1 +1,4 @@
-﻿module Program = let [<EntryPoint>] main _ = 0
+﻿module Program
+
+    [<EntryPoint>]
+    let main _ = 0


### PR DESCRIPTION
The NUnit and XUnit F# templates fail to compile when targeting net48.

repro:
- Make a new F# XUnit test template.
- Change the targetframework to net48
- Rebuild and observe the output
````
Build started at 2:24 PM...
1>------ Build started: Project: TestProject1, Configuration: Debug Any CPU ------
1>C:\Program Files\dotnet\sdk\9.0.100-preview.2.24155.28\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.RuntimeIdentifierInference.targets(314,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
1>C:\temp\test\TestProject1\TestProject1\Program.fs(1,1): error FS0222: Files in libraries or multiple-file applications must begin with a namespace or module declaration. When using a module declaration at the start of a file the '=' sign is not allowed. If this is a top-level module, consider removing the = to resolve this error.
1>Done building project "TestProject1.fsproj" -- FAILED.
========== Build: 0 succeeded, 1 failed, 0 up-to-date, 0 skipped ==========
========== Build completed at 2:24 PM and took 02.335 seconds ==========
````

This PR fixes it by changing Program.fs to:
````
module Program

    [<EntryPoint>]
    let main _ = 0
````
