### PR TITLE
Update MSTest templates to display errors on console by default

### DIFF
--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -7,6 +7,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <!--
+      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
+      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
+      -->
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
   </PropertyGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -5,6 +5,11 @@
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
     <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <!--
+      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
+      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
+      -->
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
   </PropertyGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
@@ -5,6 +5,11 @@
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net9.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <!--
+      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
+      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
+      -->
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
   </PropertyGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
@@ -8,6 +8,11 @@
     <Nullable>enable</Nullable>
     <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
     <EnablePlaywright>true</EnablePlaywright>
+    <!--
+      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
+      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
+      -->
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates default user experience when using MSTest SDK to display errors on the console. This improves "interactive" user experience by paying a small contention cost.