### PR TITLE
Remove IsPackable option from MSTest templates

### DIFF
--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/.template.config/dotnetcli.host.json
@@ -9,10 +9,6 @@
     "Framework": {
       "longName": "framework"
     },
-    "EnablePack": {
-      "shortName": "p",
-      "longName": "enable-pack"
-    },
     "UseVSTest": {
       "shortName": "",
       "longName": "use-vstest"

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/.template.config/template.json
@@ -36,12 +36,6 @@
       "replaces": "net9.0",
       "defaultValue": "net9.0"
     },
-    "EnablePack": {
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "false",
-      "description": "Whether or not to enable packaging (via \"dotnet pack\") for the project."
-    },
     "UseVSTest": {
       "type": "parameter",
       "datatype": "bool",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -7,7 +7,6 @@
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
     <!--
       Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
       For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/.template.config/dotnetcli.host.json
@@ -9,10 +9,6 @@
     "Framework": {
       "longName": "framework"
     },
-    "EnablePack": {
-      "shortName": "p",
-      "longName": "enable-pack"
-    },
     "UseVSTest": {
       "shortName": "",
       "longName": "use-vstest"

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/.template.config/template.json
@@ -36,12 +36,6 @@
       "replaces": "net9.0",
       "defaultValue": "net9.0"
     },
-    "EnablePack": {
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "false",
-      "description": "Whether or not to enable packaging (via \"dotnet pack\") for the project."
-    },
     "UseVSTest": {
       "type": "parameter",
       "datatype": "bool",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -5,7 +5,6 @@
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>
-    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
     <!--
       Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
       For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/.template.config/dotnetcli.host.json
@@ -9,10 +9,6 @@
     "Framework": {
       "longName": "framework"
     },
-    "EnablePack": {
-      "shortName": "p",
-      "longName": "enable-pack"
-    },
     "UseVSTest": {
       "shortName": "",
       "longName": "use-vstest"

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -36,12 +36,6 @@
       "replaces": "net9.0",
       "defaultValue": "net9.0"
     },
-    "EnablePack": {
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "false",
-      "description": "Whether or not to enable packaging (via \"dotnet pack\") for the project."
-    },
     "UseVSTest": {
       "type": "parameter",
       "datatype": "bool",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
@@ -5,7 +5,6 @@
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net9.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>
-    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
     <!--
       Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
       For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/.template.config/dotnetcli.host.json
@@ -9,10 +9,6 @@
     "Framework": {
       "longName": "framework"
     },
-    "EnablePack": {
-      "shortName": "p",
-      "longName": "enable-pack"
-    },
     "skipRestore": {
       "longName": "no-restore",
       "shortName": ""

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/.template.config/template.json
@@ -36,12 +36,6 @@
       "replaces": "net9.0",
       "defaultValue": "net9.0"
     },
-    "EnablePack": {
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "false",
-      "description": "Whether or not to enable packaging (via \"dotnet pack\") for the project."
-    },
     "HostIdentifier": {
       "type": "bind",
       "binding": "host:HostIdentifier"

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
@@ -7,7 +7,6 @@
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
     <EnablePlaywright>true</EnablePlaywright>
     <!--
       Displays error on console in addition to the log file. Note that this feature comes with a performance impact.


### PR DESCRIPTION
We couldn't find any valid useful scenario where we would like to pack test projects so dropping the feature from MSTest

Fixes #389 