### PR TITLE
Revert "MSTest.Sdk prefer global.json instead of local version (#396)"

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,6 +20,5 @@
   <PropertyGroup Label="Testing settings">
     <MicrosoftNetTestSdkVersion>17.8.0</MicrosoftNetTestSdkVersion>
     <MicrosoftTestPlatformVersion>$(MicrosoftNetTestSdkVersion)</MicrosoftTestPlatformVersion>
-    <MSTestVersion>3.4.1</MSTestVersion>
   </PropertyGroup>
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSTest.Sdk">
+﻿<Project Sdk="MSTest.Sdk/3.4.3">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net9.0</TargetFramework>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/global.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/global.json
@@ -1,5 +1,0 @@
-{
-  "msbuild-sdks": {
-      "MSTest.Sdk": "3.4.3"
-  }
-}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSTest.Sdk">
+﻿<Project Sdk="MSTest.Sdk/3.4.3">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net9.0</TargetFramework>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/global.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/global.json
@@ -1,5 +1,0 @@
-{
-  "msbuild-sdks": {
-      "MSTest.Sdk": "3.4.3"
-  }
-}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSTest.Sdk">
+﻿<Project Sdk="MSTest.Sdk/3.4.3">
 
   <PropertyGroup>
     <RootNamespace>Company.TestProject1</RootNamespace>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/global.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/global.json
@@ -1,5 +1,0 @@
-{
-  "msbuild-sdks": {
-      "MSTest.Sdk": "3.4.3"
-  }
-}

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSTest.Sdk">
+﻿<Project Sdk="MSTest.Sdk/3.4.3">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net9.0</TargetFramework>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/global.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/global.json
@@ -1,5 +1,0 @@
-{
-  "msbuild-sdks": {
-      "MSTest.Sdk": "3.4.3"
-  }
-}


### PR DESCRIPTION
While I am exploring solutions to edit existing `global.json` file I am reverting commit 94dba3ac75c7a9247672c6d00c00af6af617b53c.

Relates to issue https://github.com/dotnet/sdk/pull/41843

