### PR TITLE
Fix MSTest References

### DIFF
--- a/WizardExtensions/MSTestv2UnitTestExtension/MSTestv2SolutionManager.cs
+++ b/WizardExtensions/MSTestv2UnitTestExtension/MSTestv2SolutionManager.cs
@@ -46,13 +46,10 @@ namespace MSTestv2UnitTestExtension
             {
                 throw new ArgumentNullException("unitTestProject");
             }
-
-            TraceLogger.LogInfo("MSTestv2SolutionManager.OnUnitTestProjectCreated: Adding reference to MSTestv2 assemblies through nuget.");
-
+            
             base.OnUnitTestProjectCreated(unitTestProject, sourceMethod);
 
-            this.EnsureNuGetReference(unitTestProject, "MSTest.TestAdapter", "2.2.10");
-            this.EnsureNuGetReference(unitTestProject, "MSTest.TestFramework", "2.2.10");
+            // Note: we don't add the test framework reference since it is already included in the test project template
 
             VSProject2 vsp = unitTestProject.Object as VSProject2;
             if (vsp != null)


### PR DESCRIPTION
Turns out that in the new template they use new package `MSTest` `<PackageReference Include="MSTest" Version="3.2.0" />` instead of 
    
```
<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
```

So to fix it, we just simply not adding those package in our code and let test project template handle them all
