### PR TITLE
Don't prefix file name with path delimiter

### DIFF
--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/.template.config/template.json
@@ -83,7 +83,7 @@
       "manualInstructions": [ { "text": "Add a new property 'MSTest.Sdk' under 'msbuild-sdks' section of the 'global.json' file." }],
       "actionId": "695A3659-EB40-4FF5-A6A6-C9C4E629FCB0",
       "args": {
-        "jsonFileName": ".\\global.json",
+        "jsonFileName": "global.json",
         "parentPropertyPath": "msbuild-sdks",
         "newJsonPropertyName": "MSTest.Sdk",
         "newJsonPropertyValue": "3.5.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/.template.config/template.json
@@ -79,7 +79,7 @@
       "manualInstructions": [ { "text": "Add a new property 'MSTest.Sdk' under 'msbuild-sdks' section of the 'global.json' file." }],
       "actionId": "695A3659-EB40-4FF5-A6A6-C9C4E629FCB0",
       "args": {
-        "jsonFileName": ".\\global.json",
+        "jsonFileName": "global.json",
         "parentPropertyPath": "msbuild-sdks",
         "newJsonPropertyName": "MSTest.Sdk",
         "newJsonPropertyValue": "3.5.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -79,7 +79,7 @@
       "manualInstructions": [ { "text": "Add a new property 'MSTest.Sdk' under 'msbuild-sdks' section of the 'global.json' file." }],
       "actionId": "695A3659-EB40-4FF5-A6A6-C9C4E629FCB0",
       "args": {
-        "jsonFileName": ".\\global.json",
+        "jsonFileName": "global.json",
         "parentPropertyPath": "msbuild-sdks",
         "newJsonPropertyName": "MSTest.Sdk",
         "newJsonPropertyValue": "3.5.0",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/.template.config/template.json
@@ -77,7 +77,7 @@
       "manualInstructions": [ { "text": "Add a new property 'MSTest.Sdk' under 'msbuild-sdks' section of the 'global.json' file." }],
       "actionId": "695A3659-EB40-4FF5-A6A6-C9C4E629FCB0",
       "args": {
-        "jsonFileName": ".\\global.json",
+        "jsonFileName": "global.json",
         "parentPropertyPath": "msbuild-sdks",
         "newJsonPropertyName": "MSTest.Sdk",
         "newJsonPropertyValue": "3.5.0",


### PR DESCRIPTION
The path prefix I tool as example from repos implementing this post-action isn't working on Linux (see https://github.com/dotnet/sdk/pull/42272). There is no good reason to keep the path delimiter.