### PR TITLE
Fix MSTest References - PR2

### DIFF
--- a/WizardExtensions/MSTestv2UnitTestExtension/MSTestv2SolutionManager.cs
+++ b/WizardExtensions/MSTestv2UnitTestExtension/MSTestv2SolutionManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace MSTestv2UnitTestExtension
@@ -50,17 +50,6 @@ namespace MSTestv2UnitTestExtension
             base.OnUnitTestProjectCreated(unitTestProject, sourceMethod);
 
             // Note: we don't add the test framework reference since it is already included in the test project template
-
-            VSProject2 vsp = unitTestProject.Object as VSProject2;
-            if (vsp != null)
-            {
-                Reference reference = vsp.References.Find(GlobalConstants.MSTestAssemblyName);
-                if (reference != null)
-                {
-                    TraceLogger.LogInfo("MSTestv2SolutionManager.OnUnitTestProjectCreated: Removing reference to {0}", reference.Name);
-                    reference.Remove();
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Follow up PR for https://github.com/dotnet/test-templates/pull/427

Test project templates manage all MSTest references.  So we don't need to add MSTestv2 references and remove the MSTestv1 references manually. With the previous PR and this PR, the logic wll be:
1. CPS project: Latest MSTestv2 references(MSTest for NET9, MSTest.TestAdapter and MSTest.TestFramework for the rest) are added
2. Non-CPS project: MSTestv1 references("Microsoft.VisualStudio.QualityTools.UnitTestFramework") are added 
