### PR TITLE
MSTest: revert to local version instead of global.json

### DIFF
--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/.template.config/template.json
@@ -217,20 +217,6 @@
   "defaultName": "TestProject1",
   "postActions": [
     {
-      "description": "Add MSTest.Sdk entry to global.json",
-      "manualInstructions": [ { "text": "Add a new property 'MSTest.Sdk' under 'msbuild-sdks' section of the 'global.json' file." }],
-      "actionId": "695A3659-EB40-4FF5-A6A6-C9C4E629FCB0",
-      "args": {
-        "jsonFileName": "global.json",
-        "parentPropertyPath": "msbuild-sdks",
-        "newJsonPropertyName": "MSTest.Sdk",
-        "newJsonPropertyValue": "3.5.0",
-        "allowFileCreation": true,
-        "allowPathCreation": true
-      },
-      "continueOnError": true
-    },
-    {
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSTest.Sdk">
+﻿<Project Sdk="MSTest.Sdk/3.5.1">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net9.0</TargetFramework>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/.template.config/template.json
@@ -205,20 +205,6 @@
   "defaultName": "TestProject1",
   "postActions": [
     {
-      "description": "Add MSTest.Sdk entry to global.json",
-      "manualInstructions": [ { "text": "Add a new property 'MSTest.Sdk' under 'msbuild-sdks' section of the 'global.json' file." }],
-      "actionId": "695A3659-EB40-4FF5-A6A6-C9C4E629FCB0",
-      "args": {
-        "jsonFileName": "global.json",
-        "parentPropertyPath": "msbuild-sdks",
-        "newJsonPropertyName": "MSTest.Sdk",
-        "newJsonPropertyValue": "3.5.0",
-        "allowFileCreation": true,
-        "allowPathCreation": true
-      },
-      "continueOnError": true
-    },
-    {
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSTest.Sdk">
+﻿<Project Sdk="MSTest.Sdk/3.5.1">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net9.0</TargetFramework>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -217,20 +217,6 @@
   "defaultName": "TestProject1",
   "postActions": [
     {
-      "description": "Add MSTest.Sdk entry to global.json",
-      "manualInstructions": [ { "text": "Add a new property 'MSTest.Sdk' under 'msbuild-sdks' section of the 'global.json' file." }],
-      "actionId": "695A3659-EB40-4FF5-A6A6-C9C4E629FCB0",
-      "args": {
-        "jsonFileName": "global.json",
-        "parentPropertyPath": "msbuild-sdks",
-        "newJsonPropertyName": "MSTest.Sdk",
-        "newJsonPropertyValue": "3.5.0",
-        "allowFileCreation": true,
-        "allowPathCreation": true
-      },
-      "continueOnError": true
-    },
-    {
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSTest.Sdk">
+﻿<Project Sdk="MSTest.Sdk/3.5.1">
 
   <PropertyGroup>
     <RootNamespace>Company.TestProject1</RootNamespace>


### PR DESCRIPTION
Some tests of the SDK repo are not working for F# and VB.NET (manual tests are showing it's working fine) and are not easily debuggable. Besides, it seems that the post-action is not handled by VS for the moment.

For these reasons, I am rollbacking to be using locally defined version.