### PR TITLE
Update MSTest templates to not use SDK by default

### DIFF
--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/.template.config/dotnetcli.host.json
@@ -13,6 +13,10 @@
       "longName": "no-restore",
       "shortName": ""
     },
+    "UseMSTestSdk": {
+      "shortName": "",
+      "longName": "--sdk"
+    },
     "TestRunner": {
       "shortName": "",
       "longName": "test-runner"

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/.template.config/dotnetcli.host.json
@@ -15,7 +15,7 @@
     },
     "UseMSTestSdk": {
       "shortName": "",
-      "longName": "--sdk"
+      "longName": "sdk"
     },
     "TestRunner": {
       "shortName": "",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/.template.config/ide.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/.template.config/ide.host.json
@@ -3,6 +3,14 @@
   "icon": "ide/icon.ico",
   "symbolInfo": [
     {
+      "id": "UseMSTestSdk",
+      "name": {
+        "text": "Use MSTest.Sdk"
+      },
+      "isVisible": true,
+      "persistenceScope": "shared"
+    },
+    {
       "id": "TestRunner",
       "name": {
         "text": "Test runner"

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/.template.config/template.json
@@ -110,6 +110,12 @@
       "replaces": "$(ProjectLanguageVersion)",
       "displayName": "Language version"
     },
+    "UseMSTestSdk": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "Use MSTest.Sdk project style. More information at https://aka.ms/mstest/sdk",
+      "defaultValue": "False"
+    },
     "TestRunner": {
       "type": "parameter",
       "datatype": "choice",
@@ -147,7 +153,7 @@
       "type": "parameter",
       "datatype": "choice",
       "description": "Select the SDK extensions profile when using MSTest Runner. More information at https://aka.ms/mstest/sdk/extensions-profile",
-      "isEnabled": "TestRunner == MSTest",
+      "isEnabled": "(ProjectKind == MSTest.Sdk) && (TestRunner == MSTest)",
       "defaultValue": "Default",
       "replaces": "$(ExtensionsProfile)",
       "choices": [
@@ -208,11 +214,11 @@
     { "path": "Company.TestProject1.csproj" },
     {
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-      "path": "Test1.cs"
+      "path": "MSTestSettings.cs"
     },
     {
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-      "path": "MSTestSettings.cs"
+      "path": "Test1.cs"
     }
   ],
   "defaultName": "TestProject1",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -1,4 +1,5 @@
-﻿<Project Sdk="MSTest.Sdk/3.6.0">
+﻿<!--#if (UseMSTestSdk)-->
+<Project Sdk="MSTest.Sdk/3.6.0">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net9.0</TargetFramework>
@@ -27,3 +28,45 @@
 <!--#endif-->
 
 </Project>
+<!--#else-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net9.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
+    <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+<!--#if (TestRunner == "MSTest")-->
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <!--
+      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
+      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
+      -->
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
+<!--#endif-->
+  </PropertyGroup>
+
+  <ItemGroup>
+<!--#if (CoverageTool == "coverlet")-->
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+<!--#endif-->
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+<!--#if (TestRunner == "MSTest")-->
+<!--#if (CoverageTool == "Microsoft.CodeCoverage")-->
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.12.4" />
+<!--#endif-->
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.4.0" />
+<!--#endif-->
+    <PackageReference Include="MSTest" Version="3.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+</Project>
+<!--#endif-->

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/.template.config/dotnetcli.host.json
@@ -13,6 +13,10 @@
       "longName": "no-restore",
       "shortName": ""
     },
+    "UseMSTestSdk": {
+      "shortName": "",
+      "longName": "--sdk"
+    },
     "TestRunner": {
       "shortName": "",
       "longName": "test-runner"

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/.template.config/dotnetcli.host.json
@@ -15,7 +15,7 @@
     },
     "UseMSTestSdk": {
       "shortName": "",
-      "longName": "--sdk"
+      "longName": "sdk"
     },
     "TestRunner": {
       "shortName": "",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/.template.config/ide.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/.template.config/ide.host.json
@@ -3,6 +3,14 @@
   "icon": "ide/icon.ico",
   "symbolInfo": [
     {
+      "id": "UseMSTestSdk",
+      "name": {
+        "text": "Use MSTest.Sdk"
+      },
+      "isVisible": true,
+      "persistenceScope": "shared"
+    },
+    {
       "id": "TestRunner",
       "name": {
         "text": "Test runner"

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/.template.config/template.json
@@ -92,49 +92,6 @@
       "replaces": "net9.0",
       "defaultValue": "net9.0"
     },
-    "UseVSTest": {
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "false",
-      "description": "Use VSTest platform instead of MSTest runner. More information at https://aka.ms/mstest/sdk/runner"
-    },
-    "ExtensionsProfile": {
-      "type": "parameter",
-      "datatype": "choice",
-      "choices": [
-        {
-          "choice": "Default",
-          "description": "Default extensions profile (recommended)"
-        },
-        {
-          "choice": "None",
-          "description": "No extensions are enabled"
-        },
-        {
-          "choice": "AllMicrosoft",
-          "description": "Enable all extensions shipped by Microsoft (including extensions with a restrictive license)"
-        }
-      ],
-      "defaultValue": "Default",
-      "description": "Select the SDK extensions profile when using MSTest Runner. More information at https://aka.ms/mstest/sdk/extensions-profile",
-      "replaces": "$(ExtensionsProfile)"
-    },
-    "CoverageTool": {
-      "type": "parameter",
-      "datatype": "choice",
-      "choices": [
-        {
-          "choice": "Microsoft.CodeCoverage",
-          "description": "Microsoft Code Coverage"
-        },
-        {
-          "choice": "coverlet",
-          "description": "coverlet"
-        }
-      ],
-      "defaultValue": "Microsoft.CodeCoverage",
-      "description": "The coverage tool to use for the project."
-    },
     "HostIdentifier": {
       "type": "bind",
       "binding": "host:HostIdentifier"
@@ -152,6 +109,67 @@
       "defaultValue": "latest",
       "replaces": "$(ProjectLanguageVersion)",
       "displayName": "Language version"
+    },
+    "UseMSTestSdk": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "Use MSTest.Sdk project style. More information at https://aka.ms/mstest/sdk",
+      "defaultValue": "False"
+    },
+    "TestRunner": {
+      "type": "parameter",
+      "datatype": "choice",
+      "enableQuotelessLiterals": true,
+      "description": "Select the runner/platform. More information at https://aka.ms/mstest/sdk/extensions-profile",
+      "defaultValue": "MSTest",
+      "choices": [
+        {
+          "choice": "MSTest",
+          "description": "Use MSTest Runner (Microsoft.Testing.Platform)"
+        },
+        {
+          "choice": "VSTest",
+          "description": "Use VSTest platform"
+        }
+      ]
+    },
+    "CoverageTool": {
+      "type": "parameter",
+      "datatype": "choice",
+      "description": "The coverage tool to use for the project.",
+      "defaultValue": "Microsoft.CodeCoverage",
+      "choices": [
+        {
+          "choice": "Microsoft.CodeCoverage",
+          "description": "Microsoft Code Coverage"
+        },
+        {
+          "choice": "coverlet",
+          "description": "coverlet"
+        }
+      ]
+    },
+    "ExtensionsProfile": {
+      "type": "parameter",
+      "datatype": "choice",
+      "description": "Select the SDK extensions profile when using MSTest Runner. More information at https://aka.ms/mstest/sdk/extensions-profile",
+      "isEnabled": "(ProjectKind == MSTest.Sdk) && (TestRunner == MSTest)",
+      "defaultValue": "Default",
+      "replaces": "$(ExtensionsProfile)",
+      "choices": [
+        {
+          "choice": "Default",
+          "description": "Default extensions profile (recommended)"
+        },
+        {
+          "choice": "None",
+          "description": "No extensions are enabled"
+        },
+        {
+          "choice": "AllMicrosoft",
+          "description": "Enable all extensions shipped by Microsoft (including extensions with a restrictive license)"
+        }
+      ]
     },
     "Fixture": {
       "type": "parameter",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -1,10 +1,13 @@
-﻿<Project Sdk="MSTest.Sdk/3.6.0">
+﻿<!--#if (UseMSTestSdk)-->
+<Project Sdk="MSTest.Sdk/3.6.0">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net9.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
 <!--#if (TestRunner == "VSTest")-->
     <UseVSTest>true</UseVSTest>
   </PropertyGroup>
@@ -30,3 +33,50 @@
   </ItemGroup>
 
 </Project>
+<!--#else-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net9.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
+    <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+<!--#if (TestRunner == "MSTest")-->
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <!--
+      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
+      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
+      -->
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
+<!--#endif-->
+  </PropertyGroup>
+
+  <ItemGroup>
+<!--#if (CoverageTool == "coverlet")-->
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+<!--#endif-->
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+<!--#if (TestRunner == "MSTest")-->
+<!--#if (CoverageTool == "Microsoft.CodeCoverage")-->
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.12.4" />
+<!--#endif-->
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.4.0" />
+<!--#endif-->
+    <PackageReference Include="MSTest" Version="3.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="MSTestSettings.fs" />
+    <Compile Include="Test1.fs" />
+  </ItemGroup>
+
+</Project>
+<!--#endif-->

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/.template.config/dotnetcli.host.json
@@ -13,6 +13,10 @@
       "longName": "no-restore",
       "shortName": ""
     },
+    "UseMSTestSdk": {
+      "shortName": "",
+      "longName": "--sdk"
+    },
     "TestRunner": {
       "shortName": "",
       "longName": "test-runner"

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/.template.config/dotnetcli.host.json
@@ -15,7 +15,7 @@
     },
     "UseMSTestSdk": {
       "shortName": "",
-      "longName": "--sdk"
+      "longName": "sdk"
     },
     "TestRunner": {
       "shortName": "",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/.template.config/ide.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/.template.config/ide.host.json
@@ -3,6 +3,14 @@
   "icon": "ide/icon.ico",
   "symbolInfo": [
     {
+      "id": "UseMSTestSdk",
+      "name": {
+        "text": "Use MSTest.Sdk"
+      },
+      "isVisible": true,
+      "persistenceScope": "shared"
+    },
+    {
       "id": "TestRunner",
       "name": {
         "text": "Test runner"

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -110,6 +110,12 @@
       "replaces": "$(ProjectLanguageVersion)",
       "displayName": "Language version"
     },
+    "UseMSTestSdk": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "Use MSTest.Sdk project style. More information at https://aka.ms/mstest/sdk",
+      "defaultValue": "False"
+    },
     "TestRunner": {
       "type": "parameter",
       "datatype": "choice",
@@ -147,7 +153,7 @@
       "type": "parameter",
       "datatype": "choice",
       "description": "Select the SDK extensions profile when using MSTest Runner. More information at https://aka.ms/mstest/sdk/extensions-profile",
-      "isEnabled": "TestRunner == MSTest",
+      "isEnabled": "(ProjectKind == MSTest.Sdk) && (TestRunner == MSTest)",
       "defaultValue": "Default",
       "replaces": "$(ExtensionsProfile)",
       "choices": [
@@ -208,11 +214,11 @@
     { "path": "Company.TestProject1.vbproj" },
     {
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-      "path": "Test1.vb"
+      "path": "MSTestSettings.vb"
     },
     {
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-      "path": "MSTestSettings.vb"
+      "path": "Test1.vb"
     }
   ],
   "defaultName": "TestProject1",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
@@ -1,10 +1,13 @@
-﻿<Project Sdk="MSTest.Sdk/3.6.0">
+﻿<!--#if (UseMSTestSdk)-->
+<Project Sdk="MSTest.Sdk/3.6.0">
 
   <PropertyGroup>
-    <RootNamespace>Company.TestProject1</RootNamespace>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net9.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
 <!--#if (TestRunner == "VSTest")-->
     <UseVSTest>true</UseVSTest>
   </PropertyGroup>
@@ -25,3 +28,45 @@
 <!--#endif-->
 
 </Project>
+<!--#else-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net9.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
+    <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+<!--#if (TestRunner == "MSTest")-->
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <!--
+      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
+      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
+      -->
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
+<!--#endif-->
+  </PropertyGroup>
+
+  <ItemGroup>
+<!--#if (CoverageTool == "coverlet")-->
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+<!--#endif-->
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+<!--#if (TestRunner == "MSTest")-->
+<!--#if (CoverageTool == "Microsoft.CodeCoverage")-->
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.12.4" />
+<!--#endif-->
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.4.0" />
+<!--#endif-->
+    <PackageReference Include="MSTest" Version="3.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+</Project>
+<!--#endif-->

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/.template.config/dotnetcli.host.json
@@ -13,6 +13,10 @@
       "longName": "no-restore",
       "shortName": ""
     },
+    "UseMSTestSdk": {
+      "shortName": "",
+      "longName": "--sdk"
+    },
     "TestRunner": {
       "shortName": "",
       "longName": "test-runner"

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/.template.config/dotnetcli.host.json
@@ -15,7 +15,7 @@
     },
     "UseMSTestSdk": {
       "shortName": "",
-      "longName": "--sdk"
+      "longName": "sdk"
     },
     "TestRunner": {
       "shortName": "",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/.template.config/ide.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/.template.config/ide.host.json
@@ -3,6 +3,14 @@
   "icon": "ide/icon.ico",
   "symbolInfo": [
     {
+      "id": "UseMSTestSdk",
+      "name": {
+        "text": "Use MSTest.Sdk"
+      },
+      "isVisible": true,
+      "persistenceScope": "shared"
+    },
+    {
       "id": "TestRunner",
       "name": {
         "text": "Test runner"

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/.template.config/template.json
@@ -110,6 +110,12 @@
       "replaces": "$(ProjectLanguageVersion)",
       "displayName": "Language version"
     },
+    "UseMSTestSdk": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "Use MSTest.Sdk project style. More information at https://aka.ms/mstest/sdk",
+      "defaultValue": "False"
+    },
     "TestRunner": {
       "type": "parameter",
       "datatype": "choice",
@@ -147,7 +153,7 @@
       "type": "parameter",
       "datatype": "choice",
       "description": "Select the SDK extensions profile when using MSTest Runner. More information at https://aka.ms/mstest/sdk/extensions-profile",
-      "isEnabled": "TestRunner == MSTest",
+      "isEnabled": "(ProjectKind == MSTest.Sdk) && (TestRunner == MSTest)",
       "defaultValue": "Default",
       "replaces": "$(ExtensionsProfile)",
       "choices": [
@@ -208,11 +214,11 @@
     { "path": "Company.TestProject1.csproj" },
     {
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-      "path": "Test1.cs"
+      "path": "MSTestSettings.cs"
     },
     {
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-      "path": "MSTestSettings.cs"
+      "path": "Test1.cs"
     }
   ],
   "defaultName": "TestProject1",

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
@@ -1,4 +1,5 @@
-﻿<Project Sdk="MSTest.Sdk/3.6.0">
+﻿<!--#if (UseMSTestSdk)-->
+<Project Sdk="MSTest.Sdk/3.6.0">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net9.0</TargetFramework>
@@ -27,9 +28,50 @@
   </PropertyGroup>
 <!--#endif-->
 
+</Project>
+<!--#else-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net9.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
+    <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+<!--#if (TestRunner == "MSTest")-->
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <!--
+      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
+      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
+      -->
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
+<!--#endif-->
+  </PropertyGroup>
+
   <ItemGroup>
+<!--#if (CoverageTool == "coverlet")-->
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+<!--#endif-->
+    <PackageReference Include="Microsoft.Playwright.MSTest" Version="1.47.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+<!--#if (TestRunner == "MSTest")-->
+<!--#if (CoverageTool == "Microsoft.CodeCoverage")-->
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.12.4" />
+<!--#endif-->
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.4.0" />
+<!--#endif-->
+    <PackageReference Include="MSTest" Version="3.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.Playwright.MSTest" />
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
     <Using Include="System.Text.RegularExpressions" />
     <Using Include="System.Threading.Tasks" />
   </ItemGroup>
 
 </Project>
+<!--#endif-->


### PR DESCRIPTION
CLI help:

![image](https://github.com/user-attachments/assets/b66dbb07-33e7-48c8-b5d6-c241ff39a68d)

Visual Studio Wizard:

![image](https://github.com/user-attachments/assets/93afb70e-02b5-47e8-9d63-76a8b3f16914)

Project template:

![image](https://github.com/user-attachments/assets/62200ee2-c51f-4922-a22b-83f25b4bab3a)
