### PR TITLE
Clean up

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -6,15 +6,6 @@
             "component": {
                 "type": "nuget",
                 "nuget": {
-                    "name": "Microsoft.NET.Test.Sdk",
-                    "version": "17.12.0"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "nuget",
-                "nuget": {
                     "name": "MSTest.TestAdapter",
                     "version": "2.2.10"
                 }

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,11 +10,5 @@
   </PropertyGroup>
   <PropertyGroup Label="Dependencies settings">
     <MicrosoftVisualStudioCoreUtilityVersion>15.0.26201</MicrosoftVisualStudioCoreUtilityVersion>
-    <MicrosoftVSSDKBuildToolsVersion>17.4.2116</MicrosoftVSSDKBuildToolsVersion>
-  </PropertyGroup>
-  <PropertyGroup Label="Testing settings">
-    <!-- Arcade is messing up with the properties of MSTest.Sdk so we need to set explicitly MicrosoftNetTestSdkVersion and MSTestVersion -->
-    <MicrosoftNetTestSdkVersion>17.11.1</MicrosoftNetTestSdkVersion>
-    <MSTestVersion>3.6.4</MSTestVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This pull request removes outdated dependencies related to testing and updates configuration files to simplify dependency management. The most important changes include the removal of `Microsoft.NET.Test.Sdk` from the `cgmanifest.json` file and the removal of testing-related properties from `eng/Versions.props`.

### Dependency Cleanup:

* [`cgmanifest.json`](diffhunk://#diff-45a0a38d395bf4427d0291d9c72bd99b57fa43e14b00e059ae170d657949f1f2L5-L13): Removed the `Microsoft.NET.Test.Sdk` component registration, as it is no longer required.

* [`eng/Versions.props`](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L13-L18): Removed properties `MicrosoftNetTestSdkVersion` and `MSTestVersion`, along with a comment explaining their explicit setting, as they are no longer necessary. Also removed the `MicrosoftVSSDKBuildToolsVersion` property.