### PR TITLE
Fix versions.props

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,5 +10,6 @@
   </PropertyGroup>
   <PropertyGroup Label="Dependencies settings">
     <MicrosoftVisualStudioCoreUtilityVersion>15.0.26201</MicrosoftVisualStudioCoreUtilityVersion>
+    <MicrosoftVSSDKBuildToolsVersion>17.4.2116</MicrosoftVSSDKBuildToolsVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This pull request updates the dependencies in the `eng/Versions.props` file to ensure compatibility with newer tools.

Dependency update:

* Added a new property, `<MicrosoftVSSDKBuildToolsVersion>`, with the value `17.4.2116` to specify the version of the Visual Studio SDK Build Tools being used.

Previously, the repo was not able to build.