### PR TITLE
disable oneloc

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -119,15 +119,7 @@ extends:
                 dropFolder: 'artifacts\VSSetup\$(_BuildConfig)\Insertion'
                 accessToken: $(dn-bot-devdiv-drop-rw-code-rw)
               condition: succeeded()
-
-      - ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
-        - template: /eng/common/templates-official/job/onelocbuild.yml@self
-          parameters:
-            GitHubOrg: dotnet
-            MirrorRepo: test-templates
-            LclSource: lclFilesfromPackage
-            LclPackageId: 'LCL-JUNO-PROD-TESTEMPLATE'
-
+              
     - template: \eng\common\templates-official\post-build\post-build.yml@self
       parameters:
         publishingInfraVersion: 3


### PR DESCRIPTION
This pull request removes an unused OneLocBuild job template from the Azure Pipelines configuration file `azure-pipelines-official.yml`. 

Pipeline configuration cleanup:

* Removed the conditional inclusion of the `onelocbuild.yml` template, which was tied to the `main` branch and included parameters for localization builds. This cleanup simplifies the pipeline configuration by eliminating unused or unnecessary steps.