### PR TITLE
Set EnableMSTestRunner along with UseMSTestRunner

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,6 +21,8 @@
     <TestRunnerName>MSTest</TestRunnerName>
     <UseMSTestSdk>true</UseMSTestSdk>
     <UseMSTestRunner>true</UseMSTestRunner>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+
     <!-- We use MSTest.Sdk so we don't need arcade to add the Microsoft.NET.Test.Sdk package -->
     <ExcludeMicrosoftNetTestSdk>true</ExcludeMicrosoftNetTestSdk>
   </PropertyGroup>


### PR DESCRIPTION
Once https://github.com/dotnet/arcade/pull/15883 flows to this repo, we can safely remove `UseMSTestRunner` completely.