### PR TITLE
Replace dn-bot-devdiv-drop-rw-code-rw PAT with WIF service connection

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -116,10 +116,20 @@ extends:
             - script: dir /S artifacts\VSSetup\$(_BuildConfig)\Insertion
               displayName: 'List Insertion files to upload'
 
+            - task: AzureCLI@2
+              displayName: 'Get DevDiv drop token (WIF)'
+              inputs:
+                azureSubscription: 'dnceng-devdiv-drop-rw-code-rw-wif'
+                scriptType: pscore
+                scriptLocation: inlineScript
+                inlineScript: |
+                  $token = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+                  Write-Host "##vso[task.setvariable variable=DevDivDropAccessToken;issecret=true]$token"
+
             - task: 1ES.MicroBuildVstsDrop@1
               displayName: Upload Azure DevOps Drop
               inputs:
                 dropName: $(VisualStudioDropName)
                 dropFolder: 'artifacts\VSSetup\$(_BuildConfig)\Insertion'
-                accessToken: $(dn-bot-devdiv-drop-rw-code-rw)
+                accessToken: $(DevDivDropAccessToken)
               condition: succeeded()


### PR DESCRIPTION
Migrate from `dn-bot-devdiv-drop-rw-code-rw` PAT to `dnceng-devdiv-drop-rw-code-rw-wif` WIF service connection for the `1ES.MicroBuildVstsDrop@1` drop upload task.

**Changes:**
- Added `AzureCLI@2` step using the WIF SC to acquire a short-lived DevDiv-scoped access token
- Replaced `accessToken: $(dn-bot-devdiv-drop-rw-code-rw)` with `accessToken: $(DevDivDropAccessToken)`

**Why:**
The `dn-bot-devdiv-drop-rw-code-rw` PAT is being retired under the 1ES PAT Disable Policy. This replaces it with a WIF-backed identity that uses federated OIDC authentication — no long-lived secrets.

**Validation:**
Build [2952127](https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_build/results?buildId=2952127) ran from this branch on `test-templates-official-ci` (def 319) and **succeeded** — both the WIF token acquisition and drop upload to `devdiv.artifacts.visualstudio.com` completed successfully.

**Service connection:** `dnceng-devdiv-drop-rw-code-rw-wif` (ARM WIF, App ID: `7106a410-fbcb-4750-a202-879077f925ec`)

Related: dnceng/internal#10146
